### PR TITLE
feat: Add Claude Code slash commands support

### DIFF
--- a/src/main/lib/trpc/routers/commands.ts
+++ b/src/main/lib/trpc/routers/commands.ts
@@ -1,0 +1,144 @@
+import { z } from "zod"
+import { router, publicProcedure } from "../index"
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+import matter from "gray-matter"
+
+interface FileCommand {
+  name: string
+  description: string
+  argumentHint?: string
+  source: "user" | "project"
+  path: string
+}
+
+function parseCommandMd(content: string): { description?: string; argumentHint?: string } {
+  try {
+    const { data } = matter(content)
+    return {
+      description: typeof data.description === "string" ? data.description : undefined,
+      argumentHint: typeof data["argument-hint"] === "string" ? data["argument-hint"] : undefined,
+    }
+  } catch (err) {
+    console.error("[commands] Failed to parse frontmatter:", err)
+    return {}
+  }
+}
+
+function isValidEntryName(name: string): boolean {
+  return !name.includes("..") && !name.includes("/") && !name.includes("\\")
+}
+
+async function scanCommandsDirectory(
+  dir: string,
+  source: "user" | "project",
+  prefix = "",
+): Promise<FileCommand[]> {
+  const commands: FileCommand[] = []
+
+  try {
+    await fs.access(dir)
+  } catch {
+    return commands
+  }
+
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!isValidEntryName(entry.name)) {
+        console.warn(`[commands] Skipping invalid entry name: ${entry.name}`)
+        continue
+      }
+
+      const fullPath = path.join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        const nestedCommands = await scanCommandsDirectory(
+          fullPath,
+          source,
+          prefix ? `${prefix}:${entry.name}` : entry.name,
+        )
+        commands.push(...nestedCommands)
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        const baseName = entry.name.replace(/\.md$/, "")
+        const commandName = prefix ? `${prefix}:${baseName}` : baseName
+
+        try {
+          const content = await fs.readFile(fullPath, "utf-8")
+          const parsed = parseCommandMd(content)
+
+          commands.push({
+            name: commandName,
+            description: parsed.description || "",
+            argumentHint: parsed.argumentHint,
+            source,
+            path: fullPath,
+          })
+        } catch (err) {
+          console.warn(`[commands] Failed to read ${fullPath}:`, err)
+        }
+      }
+    }
+  } catch (err) {
+    console.error(`[commands] Failed to scan directory ${dir}:`, err)
+  }
+
+  return commands
+}
+
+const listCommandsProcedure = publicProcedure
+  .input(
+    z
+      .object({
+        cwd: z.string().optional(),
+      })
+      .optional(),
+  )
+  .query(async ({ input }) => {
+    const userCommandsDir = path.join(os.homedir(), ".claude", "commands")
+    const userCommandsPromise = scanCommandsDirectory(userCommandsDir, "user")
+
+    let projectCommandsPromise = Promise.resolve<FileCommand[]>([])
+    if (input?.cwd) {
+      const projectCommandsDir = path.join(input.cwd, ".claude", "commands")
+      projectCommandsPromise = scanCommandsDirectory(projectCommandsDir, "project")
+    }
+
+    const [userCommands, projectCommands] = await Promise.all([
+      userCommandsPromise,
+      projectCommandsPromise,
+    ])
+
+    return [...projectCommands, ...userCommands]
+  })
+
+export const commandsRouter = router({
+  /**
+   * List all commands from filesystem
+   * - User commands: ~/.claude/commands/
+   * - Project commands: .claude/commands/ (relative to cwd)
+   */
+  list: listCommandsProcedure,
+
+  /**
+   * Get content of a specific command file
+   */
+  getContent: publicProcedure
+    .input(z.object({ path: z.string() }))
+    .query(async ({ input }) => {
+      if (input.path.includes("..")) {
+        throw new Error("Invalid path")
+      }
+
+      try {
+        const content = await fs.readFile(input.path, "utf-8")
+        const { content: body } = matter(content)
+        return { content: body.trim() }
+      } catch (err) {
+        console.error(`[commands] Failed to read command content:`, err)
+        return { content: "" }
+      }
+    }),
+})

--- a/src/main/lib/trpc/routers/index.ts
+++ b/src/main/lib/trpc/routers/index.ts
@@ -9,6 +9,7 @@ import { filesRouter } from "./files"
 import { debugRouter } from "./debug"
 import { skillsRouter } from "./skills"
 import { agentsRouter } from "./agents"
+import { commandsRouter } from "./commands"
 import { createGitRouter } from "../../git"
 import { BrowserWindow } from "electron"
 
@@ -28,6 +29,7 @@ export function createAppRouter(getWindow: () => BrowserWindow | null) {
     debug: debugRouter,
     skills: skillsRouter,
     agents: agentsRouter,
+    commands: commandsRouter,
     // Git operations - named "changes" to match Superset API
     changes: createGitRouter(),
   })

--- a/src/renderer/features/agents/commands/types.ts
+++ b/src/renderer/features/agents/commands/types.ts
@@ -15,6 +15,8 @@ export interface SlashCommand {
   path?: string
   // For repository commands - the repository name
   repository?: string
+  // For repository commands - hint for expected arguments (e.g. "<task description>")
+  argumentHint?: string
 }
 
 export interface SlashCommandOption extends SlashCommand {


### PR DESCRIPTION
## Summary
- Add support for Claude Code custom slash commands from `~/.claude/commands/` and `.claude/commands/`
- Scan command files recursively with namespace support (e.g., `git/commit.md` → `/git:commit`)
- Parse `argument-hint` from YAML frontmatter
- Insert command name in input instead of auto-sending, allowing users to add arguments
- Replace `$ARGUMENTS` placeholder with user-provided arguments on send

This enables using custom Claude Code CLI commands directly in 1Code, matching the behavior of the Claude Code CLI.

## Changes
- `src/main/lib/trpc/routers/commands.ts` - New router to scan and serve commands
- `src/main/lib/trpc/routers/index.ts` - Register commands router
- `src/renderer/lib/mock-api.ts` - Connect to real tRPC for commands
- `src/renderer/features/agents/commands/` - Update types and dropdown component
- `src/renderer/features/agents/main/new-chat-form.tsx` - Handle command selection and $ARGUMENTS replacement

## Test plan
- [x] Type `/` in chat input → Claude Code commands appear under "Claude Commands" section
- [x] Click on a command → inserts `/command-name ` in input (doesn't auto-send)
- [x] Type arguments after command and press Enter → `$ARGUMENTS` is replaced with your text
- [x] Nested commands work (e.g., `/apex:1-analyze`)
- [x] Commands from both user (`~/.claude/commands/`) and project (`.claude/commands/`) directories are loaded

## Reference
- Claude Code CLI slash commands: https://docs.anthropic.com/en/docs/claude-code/slash-commands