### PR TITLE
Fix IME composition issue with Enter key

### DIFF
--- a/src/renderer/components/ui/prompt-input.tsx
+++ b/src/renderer/components/ui/prompt-input.tsx
@@ -147,7 +147,8 @@ const PromptInputTextareaInner = (
   }, [value, disableAutosize, maxHeight])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+    // Prevent submission during IME composition (e.g., Chinese/Japanese/Korean input)
+    if (e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.nativeEvent.isComposing) {
       e.preventDefault()
       onSubmit?.()
     }

--- a/src/renderer/features/agents/mentions/agents-mentions-editor.tsx
+++ b/src/renderer/features/agents/mentions/agents-mentions-editor.tsx
@@ -758,7 +758,8 @@ export const AgentsMentionsEditor = memo(
       // Handle keydown
       const handleKeyDown = useCallback(
         (e: React.KeyboardEvent) => {
-          if (e.key === "Enter" && !e.shiftKey) {
+          // Prevent submission during IME composition (e.g., Chinese/Japanese/Korean input)
+          if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
             if (triggerActive.current || slashTriggerActive.current) {
               // Let dropdown handle Enter
               return


### PR DESCRIPTION
Previously, pressing Enter to select a candidate word in Chinese, Japanese, or Korean input methods would accidentally trigger message submission. This made it very difficult for CJK users to type naturally.

I have fixed this by adding an isComposing check to both AgentsMentionsEditor and PromptInputTextarea. This ensures that Enter only sends the message when the user is not in the middle of an IME composition.

I have tested this locally and confirmed it works as expected: candidate selection no longer triggers a send, while normal Enter functionality remains intact.

Changes:

 - src/renderer/features/agents/mentions/agents-mentions-editor.tsx

 - src/renderer/components/ui/prompt-input.tsx

## Demo

https://github.com/user-attachments/assets/c066af50-c2a5-4943-b814-e5c661260cd3

