### PR TITLE
feat: support existing Claude CLI configuration

### DIFF
--- a/src/main/lib/claude/env.ts
+++ b/src/main/lib/claude/env.ts
@@ -11,9 +11,10 @@ let cachedShellEnv: Record<string, string> | null = null
 // Delimiter for parsing env output
 const DELIMITER = "_CLAUDE_ENV_DELIMITER_"
 
-// Keys to strip (prevent auth interference)
+// Keys to strip (prevent interference from unrelated providers)
+// NOTE: We intentionally keep ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL
+// so users can use their existing Claude Code CLI configuration (API proxy, etc.)
 const STRIPPED_ENV_KEYS = [
-  "ANTHROPIC_API_KEY",
   "OPENAI_API_KEY",
   "CLAUDE_CODE_USE_BEDROCK",
   "CLAUDE_CODE_USE_VERTEX",

--- a/src/main/lib/trpc/routers/claude-code.ts
+++ b/src/main/lib/trpc/routers/claude-code.ts
@@ -5,6 +5,7 @@ import { getAuthManager } from "../../../index"
 import { getApiUrl } from "../../config"
 import { getDatabase, claudeCodeCredentials } from "../../db"
 import { eq } from "drizzle-orm"
+import { getClaudeShellEnvironment } from "../../claude"
 
 /**
  * Get desktop auth token for server API calls
@@ -41,6 +42,20 @@ function decryptToken(encrypted: string): string {
  * Uses server only for sandbox creation, stores token locally
  */
 export const claudeCodeRouter = router({
+  /**
+   * Check if user has existing CLI config (API key or proxy)
+   * If true, user can skip OAuth onboarding
+   */
+  hasExistingCliConfig: publicProcedure.query(() => {
+    const shellEnv = getClaudeShellEnvironment()
+    const hasConfig = !!(shellEnv.ANTHROPIC_API_KEY || shellEnv.ANTHROPIC_BASE_URL)
+    return {
+      hasConfig,
+      hasApiKey: !!shellEnv.ANTHROPIC_API_KEY,
+      baseUrl: shellEnv.ANTHROPIC_BASE_URL || null,
+    }
+  }),
+
   /**
    * Check if user has Claude Code connected (local check)
    */

--- a/src/main/lib/trpc/routers/claude.ts
+++ b/src/main/lib/trpc/routers/claude.ts
@@ -387,8 +387,16 @@ export const claudeRouter = router({
               logClaudeEnv(claudeEnv, `[${input.subChatId}] `)
             }
 
-            // Get Claude Code OAuth token from local storage (optional)
-            const claudeCodeToken = getClaudeCodeToken()
+            // Check if user has existing API key or proxy configured in their shell environment
+            // If so, use that instead of OAuth (allows using custom API proxies)
+            const hasExistingApiConfig = !!(claudeEnv.ANTHROPIC_API_KEY || claudeEnv.ANTHROPIC_BASE_URL)
+
+            if (hasExistingApiConfig) {
+              console.log(`[claude] Using existing CLI config - API_KEY: ${claudeEnv.ANTHROPIC_API_KEY ? "set" : "not set"}, BASE_URL: ${claudeEnv.ANTHROPIC_BASE_URL || "default"}`)
+            }
+
+            // Get Claude Code OAuth token from local storage (only if no existing config)
+            const claudeCodeToken = hasExistingApiConfig ? null : getClaudeCodeToken()
 
             // Create isolated config directory per subChat to prevent session contamination
             // The Claude binary stores sessions in ~/.claude/ based on cwd, which causes


### PR DESCRIPTION
## Summary

Allow users to use their existing Claude Code CLI configuration (ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL) instead of requiring OAuth authentication.

This is useful for users who:
- Use a custom API proxy
- Already have Claude CLI configured with an API key
- Want to use the app without going through OAuth flow

## Changes

- **env.ts**: Preserve `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` from shell environment (previously stripped)
- **claude-code.ts**: Add `hasExistingCliConfig` tRPC endpoint to detect CLI configuration
- **claude.ts**: Skip OAuth token when existing API config is present
- **main.ts**: Allow app access with CLI config (no OAuth required)
- **App.tsx**: Check CLI config and skip onboarding if present
- **anthropic-onboarding-page.tsx**: Show "Configuration Detected" UI with choice to use existing config or connect with OAuth

## Screenshots

When CLI config is detected, users see:
- "Claude Configuration Detected" header
- API Key status (Configured/Not set)
- API Proxy URL (if set)
- "Use Existing Configuration" primary button
- "Connect with Claude OAuth instead" secondary option

## Test Plan

- [x] Test with `ANTHROPIC_API_KEY` set in shell environment
- [x] Test with `ANTHROPIC_BASE_URL` set (custom proxy)
- [x] Test with both set
- [x] Test with neither set (should show OAuth flow)
- [x] Test "Use Existing Configuration" button
- [x] Test "Connect with Claude OAuth instead" option
- [x] Verify chat works with existing CLI config