### PR TITLE
Fix download URL for Claude binary

### DIFF
--- a/scripts/download-claude-binary.mjs
+++ b/scripts/download-claude-binary.mjs
@@ -174,7 +174,7 @@ async function downloadPlatform(version, platformKey, manifest) {
   }
 
   const expectedHash = platformManifest.checksum
-  const downloadUrl = `${DIST_BASE}/${version}/${platform.dir}/claude`
+  const downloadUrl = `${DIST_BASE}/${version}/${platform.dir}/${platform.binary}`
 
   console.log(`\nDownloading Claude Code for ${platformKey}...`)
   console.log(`  URL: ${downloadUrl}`)


### PR DESCRIPTION
 The script bug is on line 177 - it always uses claude instead of the platform-specific binary name