### PR TITLE
add desktop notifications and chat export

### DIFF
--- a/src/main/lib/analytics.ts
+++ b/src/main/lib/analytics.ts
@@ -5,6 +5,8 @@
 
 import { PostHog } from "posthog-node"
 import { app } from "electron"
+import * as fs from "fs"
+import * as path from "path"
 
 // PostHog configuration from environment
 const POSTHOG_DESKTOP_KEY = import.meta.env.MAIN_VITE_POSTHOG_KEY
@@ -13,6 +15,40 @@ const POSTHOG_HOST = import.meta.env.MAIN_VITE_POSTHOG_HOST || "https://us.i.pos
 let posthog: PostHog | null = null
 let currentUserId: string | null = null
 let userOptedOut = false // Synced from renderer
+
+// track first launch using a marker file
+const FIRST_LAUNCH_MARKER = ".first_launch_tracked"
+
+function getFirstLaunchMarkerPath(): string {
+  try {
+    return path.join(app.getPath("userData"), FIRST_LAUNCH_MARKER)
+  } catch {
+    // app not ready yet
+    return ""
+  }
+}
+
+function isFirstLaunch(): boolean {
+  const markerPath = getFirstLaunchMarkerPath()
+  if (!markerPath) return false
+
+  try {
+    return !fs.existsSync(markerPath)
+  } catch {
+    return false
+  }
+}
+
+function markFirstLaunchTracked(): void {
+  const markerPath = getFirstLaunchMarkerPath()
+  if (!markerPath) return
+
+  try {
+    fs.writeFileSync(markerPath, new Date().toISOString())
+  } catch {
+    // ignore errors writing marker
+  }
+}
 
 // Check if we're in development mode
 // Set FORCE_ANALYTICS=true to test analytics in development
@@ -157,9 +193,22 @@ export async function shutdown() {
  * Track app opened event
  */
 export function trackAppOpened() {
+  const firstLaunch = isFirstLaunch()
+
   capture("desktop_opened", {
-    first_launch: false, // TODO: track first launch
+    first_launch: firstLaunch,
   })
+
+  if (firstLaunch) {
+    // mark as tracked so subsequent opens don't count as first launch
+    markFirstLaunchTracked()
+
+    // also fire a separate first_launch event for funnel analysis
+    capture("first_launch", {
+      app_version: app.getVersion(),
+      platform: process.platform,
+    })
+  }
 }
 
 /**

--- a/src/main/lib/trpc/routers/chats.ts
+++ b/src/main/lib/trpc/routers/chats.ts
@@ -1028,4 +1028,253 @@ export const chatsRouter = router({
         return { hasWorktree: false, uncommittedCount: 0 }
       }
     }),
+
+  /**
+   * Export a chat conversation to various formats.
+   * Useful for sharing, backup, or importing into other tools.
+   */
+  exportChat: publicProcedure
+    .input(
+      z.object({
+        chatId: z.string(),
+        format: z.enum(["json", "markdown", "text"]).default("markdown"),
+        includeMetadata: z.boolean().default(false),
+      }),
+    )
+    .query(async ({ input }) => {
+      const db = getDatabase()
+      const chat = db
+        .select()
+        .from(chats)
+        .where(eq(chats.id, input.chatId))
+        .get()
+
+      if (!chat) {
+        throw new Error("Chat not found")
+      }
+
+      const project = db
+        .select()
+        .from(projects)
+        .where(eq(projects.id, chat.projectId))
+        .get()
+
+      const chatSubChats = db
+        .select()
+        .from(subChats)
+        .where(eq(subChats.chatId, input.chatId))
+        .orderBy(subChats.createdAt)
+        .all()
+
+      // parse messages from all sub-chats
+      const allMessages: Array<{
+        subChatId: string
+        subChatName: string | null
+        messages: Array<{
+          id: string
+          role: string
+          parts: Array<{ type: string; text?: string; [key: string]: any }>
+          metadata?: any
+        }>
+      }> = []
+
+      for (const subChat of chatSubChats) {
+        try {
+          const messages = JSON.parse(subChat.messages || "[]")
+          allMessages.push({
+            subChatId: subChat.id,
+            subChatName: subChat.name,
+            messages,
+          })
+        } catch {
+          // skip invalid json
+        }
+      }
+
+      if (input.format === "json") {
+        return {
+          format: "json" as const,
+          content: JSON.stringify(
+            {
+              exportedAt: new Date().toISOString(),
+              chat: {
+                id: chat.id,
+                name: chat.name,
+                createdAt: chat.createdAt,
+                branch: chat.branch,
+                baseBranch: chat.baseBranch,
+                prUrl: chat.prUrl,
+              },
+              project: project
+                ? {
+                    id: project.id,
+                    name: project.name,
+                    path: project.path,
+                  }
+                : null,
+              conversations: allMessages,
+            },
+            null,
+            2,
+          ),
+          filename: `${chat.name || "chat"}-${chat.id.slice(0, 8)}.json`,
+        }
+      }
+
+      if (input.format === "text") {
+        // plain text format
+        let text = `# ${chat.name || "Untitled Chat"}\n`
+        text += `exported: ${new Date().toISOString()}\n`
+        if (project) {
+          text += `project: ${project.name}\n`
+        }
+        text += `\n---\n\n`
+
+        for (const subChatData of allMessages) {
+          if (subChatData.subChatName) {
+            text += `## ${subChatData.subChatName}\n\n`
+          }
+
+          for (const msg of subChatData.messages) {
+            const role = msg.role === "user" ? "You" : "Assistant"
+            text += `${role}:\n`
+
+            for (const part of msg.parts || []) {
+              if (part.type === "text" && part.text) {
+                text += `${part.text}\n`
+              } else if (part.type?.startsWith("tool-") && part.toolName) {
+                text += `[used ${part.toolName} tool]\n`
+              }
+            }
+            text += "\n"
+          }
+        }
+
+        return {
+          format: "text" as const,
+          content: text,
+          filename: `${chat.name || "chat"}-${chat.id.slice(0, 8)}.txt`,
+        }
+      }
+
+      // markdown format (default)
+      let markdown = `# ${chat.name || "Untitled Chat"}\n\n`
+      markdown += `**Exported:** ${new Date().toISOString()}\n\n`
+      if (project) {
+        markdown += `**Project:** ${project.name}\n\n`
+      }
+      if (chat.branch) {
+        markdown += `**Branch:** \`${chat.branch}\`\n\n`
+      }
+      if (chat.prUrl) {
+        markdown += `**PR:** [${chat.prUrl}](${chat.prUrl})\n\n`
+      }
+      markdown += `---\n\n`
+
+      for (const subChatData of allMessages) {
+        if (subChatData.subChatName) {
+          markdown += `## ${subChatData.subChatName}\n\n`
+        }
+
+        for (const msg of subChatData.messages) {
+          const role = msg.role === "user" ? "**You**" : "**Assistant**"
+          markdown += `### ${role}\n\n`
+
+          for (const part of msg.parts || []) {
+            if (part.type === "text" && part.text) {
+              markdown += `${part.text}\n\n`
+            } else if (part.type?.startsWith("tool-") && part.toolName) {
+              const toolName = part.toolName
+              if (toolName === "Bash" && part.input?.command) {
+                markdown += `\`\`\`bash\n${part.input.command}\n\`\`\`\n\n`
+              } else if (
+                (toolName === "Edit" || toolName === "Write") &&
+                part.input?.file_path
+              ) {
+                markdown += `> Modified: \`${part.input.file_path}\`\n\n`
+              } else if (toolName === "Read" && part.input?.file_path) {
+                markdown += `> Read: \`${part.input.file_path}\`\n\n`
+              } else {
+                markdown += `> *Used ${toolName} tool*\n\n`
+              }
+            }
+          }
+        }
+      }
+
+      return {
+        format: "markdown" as const,
+        content: markdown,
+        filename: `${chat.name || "chat"}-${chat.id.slice(0, 8)}.md`,
+      }
+    }),
+
+  /**
+   * Get basic stats for a chat (message count, tool usage, etc.)
+   * Useful for showing chat summary in sidebar or export dialogs.
+   */
+  getChatStats: publicProcedure
+    .input(z.object({ chatId: z.string() }))
+    .query(({ input }) => {
+      const db = getDatabase()
+      const chatSubChats = db
+        .select()
+        .from(subChats)
+        .where(eq(subChats.chatId, input.chatId))
+        .all()
+
+      let messageCount = 0
+      let userMessageCount = 0
+      let assistantMessageCount = 0
+      let toolCalls = 0
+      const toolUsage: Record<string, number> = {}
+      let totalInputTokens = 0
+      let totalOutputTokens = 0
+
+      for (const subChat of chatSubChats) {
+        try {
+          const messages = JSON.parse(subChat.messages || "[]") as Array<{
+            role: string
+            parts?: Array<{ type: string; toolName?: string }>
+            metadata?: { usage?: { inputTokens?: number; outputTokens?: number } }
+          }>
+
+          for (const msg of messages) {
+            messageCount++
+            if (msg.role === "user") {
+              userMessageCount++
+            } else if (msg.role === "assistant") {
+              assistantMessageCount++
+
+              // count tool calls
+              for (const part of msg.parts || []) {
+                if (part.type?.startsWith("tool-") && part.toolName) {
+                  toolCalls++
+                  toolUsage[part.toolName] = (toolUsage[part.toolName] || 0) + 1
+                }
+              }
+
+              // aggregate token usage
+              if (msg.metadata?.usage) {
+                totalInputTokens += msg.metadata.usage.inputTokens || 0
+                totalOutputTokens += msg.metadata.usage.outputTokens || 0
+              }
+            }
+          }
+        } catch {
+          // skip invalid json
+        }
+      }
+
+      return {
+        messageCount,
+        userMessageCount,
+        assistantMessageCount,
+        toolCalls,
+        toolUsage,
+        totalInputTokens,
+        totalOutputTokens,
+        subChatCount: chatSubChats.length,
+      }
+    }),
 })

--- a/src/renderer/components/dialogs/export-chat-dialog.tsx
+++ b/src/renderer/components/dialogs/export-chat-dialog.tsx
@@ -1,0 +1,215 @@
+import * as React from "react"
+import { useState } from "react"
+import { createPortal } from "react-dom"
+import { Button } from "../ui/button"
+import { X, Download, FileJson, FileText, Copy, Check } from "lucide-react"
+import { trpc } from "../../lib/trpc"
+
+type ExportFormat = "markdown" | "json" | "text"
+
+interface ExportChatDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  chatId: string
+  chatName: string | null
+}
+
+export function ExportChatDialog({
+  isOpen,
+  onClose,
+  chatId,
+  chatName,
+}: ExportChatDialogProps) {
+  const [selectedFormat, setSelectedFormat] = useState<ExportFormat>("markdown")
+  const [copied, setCopied] = useState(false)
+
+  const { data: exportData, isLoading } = trpc.chats.exportChat.useQuery(
+    { chatId, format: selectedFormat },
+    { enabled: isOpen }
+  )
+
+  const { data: stats } = trpc.chats.getChatStats.useQuery(
+    { chatId },
+    { enabled: isOpen }
+  )
+
+  const handleDownload = () => {
+    if (!exportData) return
+
+    const blob = new Blob([exportData.content], { type: "text/plain;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = exportData.filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+  }
+
+  const handleCopy = async () => {
+    if (!exportData) return
+
+    try {
+      await navigator.clipboard.writeText(exportData.content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // fallback for older browsers
+      const textarea = document.createElement("textarea")
+      textarea.value = exportData.content
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand("copy")
+      document.body.removeChild(textarea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  React.useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown)
+      return () => document.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen || typeof document === "undefined") return null
+
+  const formatOptions: { value: ExportFormat; label: string; icon: React.ReactNode; description: string }[] = [
+    {
+      value: "markdown",
+      label: "Markdown",
+      icon: <FileText className="h-4 w-4" />,
+      description: "readable format with code blocks",
+    },
+    {
+      value: "json",
+      label: "JSON",
+      icon: <FileJson className="h-4 w-4" />,
+      description: "full data for import/backup",
+    },
+    {
+      value: "text",
+      label: "Plain Text",
+      icon: <FileText className="h-4 w-4" />,
+      description: "simple text without formatting",
+    },
+  ]
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100000] flex items-center justify-center">
+      {/* backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* dialog */}
+      <div className="relative bg-background border border-border rounded-lg shadow-lg w-full max-w-lg mx-4 p-6">
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <h2 className="text-lg font-semibold mb-1">Export Conversation</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          {chatName || "Untitled Chat"}
+        </p>
+
+        {/* stats */}
+        {stats && (
+          <div className="flex gap-4 text-xs text-muted-foreground mb-4 pb-4 border-b border-border">
+            <span>{stats.messageCount} messages</span>
+            <span>{stats.toolCalls} tool calls</span>
+            {stats.totalInputTokens > 0 && (
+              <span>{Math.round((stats.totalInputTokens + stats.totalOutputTokens) / 1000)}k tokens</span>
+            )}
+          </div>
+        )}
+
+        {/* format selection */}
+        <div className="space-y-2 mb-4">
+          <label className="text-sm font-medium">Format</label>
+          <div className="grid grid-cols-3 gap-2">
+            {formatOptions.map((option) => (
+              <button
+                key={option.value}
+                onClick={() => setSelectedFormat(option.value)}
+                className={`
+                  flex flex-col items-center gap-1 p-3 rounded-md border transition-colors
+                  ${selectedFormat === option.value
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-muted-foreground/50"
+                  }
+                `}
+              >
+                {option.icon}
+                <span className="text-sm font-medium">{option.label}</span>
+                <span className="text-[10px] text-muted-foreground text-center leading-tight">
+                  {option.description}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* preview */}
+        {exportData && !isLoading && (
+          <div className="mb-4">
+            <label className="text-sm font-medium mb-2 block">Preview</label>
+            <div className="bg-muted/50 rounded-md p-3 max-h-40 overflow-auto font-mono text-xs">
+              <pre className="whitespace-pre-wrap break-words">
+                {exportData.content.slice(0, 500)}
+                {exportData.content.length > 500 && "..."}
+              </pre>
+            </div>
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="mb-4 py-8 text-center text-sm text-muted-foreground">
+            preparing export...
+          </div>
+        )}
+
+        {/* actions */}
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={handleCopy}
+            disabled={!exportData || isLoading}
+          >
+            {copied ? (
+              <>
+                <Check className="h-4 w-4 mr-1" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4 mr-1" />
+                Copy
+              </>
+            )}
+          </Button>
+          <Button
+            onClick={handleDownload}
+            disabled={!exportData || isLoading}
+          >
+            <Download className="h-4 w-4 mr-1" />
+            Download
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/components/dialogs/index.ts
+++ b/src/renderer/components/dialogs/index.ts
@@ -2,6 +2,7 @@
 export { AgentsSettingsDialog } from "./agents-settings-dialog"
 export { AgentsShortcutsDialog } from "./agents-shortcuts-dialog"
 export { AgentsHelpPopover } from "./agents-help-popover"
+export { ExportChatDialog } from "./export-chat-dialog"
 
 // Settings tabs
 export { AgentsAppearanceTab } from "./settings-tabs/agents-appearance-tab"

--- a/src/renderer/features/agents/hooks/use-desktop-notifications.ts
+++ b/src/renderer/features/agents/hooks/use-desktop-notifications.ts
@@ -1,13 +1,122 @@
-// Mock desktop notifications hook for desktop app
+/**
+ * Desktop notifications hook - provides native OS notifications for agent events.
+ * Uses Electron's Notification API via the IPC bridge in desktopApi.
+ */
+
+import { useCallback, useRef } from "react"
+import { isDesktopApp } from "../../../lib/utils/platform"
+
+// throttle interval to prevent notification spam (ms)
+const NOTIFICATION_THROTTLE_MS = 3000
+
+export interface NotificationOptions {
+  title: string
+  body: string
+  silent?: boolean
+}
 
 export function useDesktopNotifications() {
+  // track last notification time to throttle rapid-fire notifications
+  const lastNotificationTime = useRef<number>(0)
+  const pendingNotification = useRef<NotificationOptions | null>(null)
+  const throttleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const showNotification = useCallback((title: string, body: string, options?: { silent?: boolean }) => {
+    if (!isDesktopApp()) {
+      // fallback for web - use browser Notification API if available
+      if ("Notification" in window && Notification.permission === "granted") {
+        new Notification(title, { body, silent: options?.silent })
+      }
+      return
+    }
+
+    const now = Date.now()
+    const timeSinceLastNotification = now - lastNotificationTime.current
+
+    // if we're within throttle window, queue this notification
+    if (timeSinceLastNotification < NOTIFICATION_THROTTLE_MS) {
+      pendingNotification.current = { title, body, silent: options?.silent }
+
+      // set up a timer to show the pending notification after throttle period
+      if (!throttleTimer.current) {
+        throttleTimer.current = setTimeout(() => {
+          throttleTimer.current = null
+          if (pendingNotification.current) {
+            const pending = pendingNotification.current
+            pendingNotification.current = null
+            showNotification(pending.title, pending.body, { silent: pending.silent })
+          }
+        }, NOTIFICATION_THROTTLE_MS - timeSinceLastNotification)
+      }
+      return
+    }
+
+    lastNotificationTime.current = now
+
+    // use the IPC bridge to show native notification
+    window.desktopApi?.showNotification({ title, body })
+  }, [])
+
+  const notifyAgentComplete = useCallback((chatName: string) => {
+    // don't notify if window is focused - user is already watching
+    if (document.hasFocus()) {
+      return
+    }
+
+    const title = "Agent Complete"
+    const body = chatName ? `Finished working on "${chatName}"` : "Agent has completed its task"
+    showNotification(title, body)
+  }, [showNotification])
+
+  const notifyAgentError = useCallback((errorMessage: string) => {
+    // always notify on errors, even if window is focused
+    const title = "Agent Error"
+    const body = errorMessage.length > 100 ? errorMessage.slice(0, 100) + "..." : errorMessage
+    showNotification(title, body)
+  }, [showNotification])
+
+  const notifyAgentNeedsInput = useCallback((chatName: string) => {
+    // don't notify if window is focused
+    if (document.hasFocus()) {
+      return
+    }
+
+    const title = "Input Required"
+    const body = chatName ? `"${chatName}" is waiting for your input` : "Agent is waiting for your input"
+    showNotification(title, body)
+  }, [showNotification])
+
+  const notifyPlanReady = useCallback((chatName: string) => {
+    // don't notify if window is focused
+    if (document.hasFocus()) {
+      return
+    }
+
+    const title = "Plan Ready"
+    const body = chatName ? `"${chatName}" has a plan ready for approval` : "A plan is ready for your approval"
+    showNotification(title, body)
+  }, [showNotification])
+
+  const requestPermission = useCallback(async (): Promise<NotificationPermission> => {
+    if (isDesktopApp()) {
+      // desktop apps don't need explicit permission for notifications
+      return "granted"
+    }
+
+    // for web, request browser permission
+    if ("Notification" in window) {
+      return await Notification.requestPermission()
+    }
+
+    return "denied"
+  }, [])
+
   return {
-    showNotification: (_title: string, _body: string) => {
-      // Desktop notification - TODO: implement real notifications
-    },
-    notifyAgentComplete: (_chatName: string) => {
-      // Agent complete notification - TODO: implement real notifications
-    },
-    requestPermission: () => Promise.resolve('granted' as NotificationPermission),
+    showNotification,
+    notifyAgentComplete,
+    notifyAgentError,
+    notifyAgentNeedsInput,
+    notifyPlanReady,
+    requestPermission,
   }
 }

--- a/src/renderer/features/agents/main/active-chat.tsx
+++ b/src/renderer/features/agents/main/active-chat.tsx
@@ -2416,7 +2416,7 @@ export function ChatView({
   const setJustCreatedIds = useSetAtom(justCreatedIdsAtom)
   const selectedChatId = useAtomValue(selectedAgentChatIdAtom)
   const setUndoStack = useSetAtom(undoStackAtom)
-  const { notifyAgentComplete } = useDesktopNotifications()
+  const { notifyAgentComplete, notifyAgentNeedsInput, notifyPlanReady } = useDesktopNotifications()
 
   // Check if any chat has unseen changes
   const hasAnyUnseenChanges = unseenChanges.size > 0
@@ -3304,6 +3304,20 @@ export function ChatView({
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [handleCreateNewSubChat])
+
+  // desktop notification for pending user questions (when window is not focused)
+  const pendingUserQuestions = useAtomValue(pendingUserQuestionsAtom)
+  const prevPendingQuestionsRef = useRef<typeof pendingUserQuestions>(null)
+  useEffect(() => {
+    // only trigger on new question appearing, not on every re-render
+    const hadQuestion = !!prevPendingQuestionsRef.current
+    const hasQuestion = !!pendingUserQuestions
+    prevPendingQuestionsRef.current = pendingUserQuestions
+
+    if (!hadQuestion && hasQuestion) {
+      notifyAgentNeedsInput(agentChat?.name || "Agent")
+    }
+  }, [pendingUserQuestions, notifyAgentNeedsInput, agentChat?.name])
 
   // Multi-select state for sub-chats (for Cmd+W bulk close)
   const selectedSubChatIds = useAtomValue(selectedSubChatIdsAtom)


### PR DESCRIPTION

  finally hooked up the desktop notifications - they were completely stubbed out before. now you actually get notified when an agent finishes working or needs your input, but only when the window isn't focused so it's not annoying.

  also added chat export functionality since there was literally no way to get your conversations out of the app. you can export to markdown, json, or plain text. the markdown format is actually pretty nice - it renders bash commands as code blocks and shows which files were edited.

  threw in first launch tracking for analytics too since there was a TODO sitting there. just drops a marker file in userData so we know if someone's opening the app for the first time.

  changes:
  - rewrote the notifications hook to use the existing IPC bridge instead of doing nothing
  - added exportChat and getChatStats endpoints to the chats router
  - new export dialog component with format picker and preview
  - first launch detection using marker file approach
  - wired up notifications for when agent needs user input