### PR TITLE
feat: Add preference to disable Co-Authored-By attribution

### DIFF
--- a/src/main/lib/trpc/routers/claude-settings.ts
+++ b/src/main/lib/trpc/routers/claude-settings.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as os from "os"
+import { z } from "zod"
+import { router, publicProcedure } from "../index"
+
+const CLAUDE_SETTINGS_PATH = path.join(os.homedir(), ".claude", "settings.json")
+
+/**
+ * Read Claude settings.json file
+ * Returns empty object if file doesn't exist
+ */
+async function readClaudeSettings(): Promise<Record<string, unknown>> {
+  try {
+    const content = await fs.readFile(CLAUDE_SETTINGS_PATH, "utf-8")
+    return JSON.parse(content)
+  } catch (error) {
+    // File doesn't exist or is invalid JSON
+    return {}
+  }
+}
+
+/**
+ * Write Claude settings.json file
+ * Creates the .claude directory if it doesn't exist
+ */
+async function writeClaudeSettings(settings: Record<string, unknown>): Promise<void> {
+  const dir = path.dirname(CLAUDE_SETTINGS_PATH)
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2), "utf-8")
+}
+
+export const claudeSettingsRouter = router({
+  /**
+   * Get the includeCoAuthoredBy setting
+   * Returns true if setting is not explicitly set to false
+   */
+  getIncludeCoAuthoredBy: publicProcedure.query(async () => {
+    const settings = await readClaudeSettings()
+    // Default is true (include co-authored-by)
+    // Only return false if explicitly set to false
+    return settings.includeCoAuthoredBy !== false
+  }),
+
+  /**
+   * Set the includeCoAuthoredBy setting
+   */
+  setIncludeCoAuthoredBy: publicProcedure
+    .input(z.object({ enabled: z.boolean() }))
+    .mutation(async ({ input }) => {
+      const settings = await readClaudeSettings()
+
+      if (input.enabled) {
+        // Remove the setting to use default (true)
+        delete settings.includeCoAuthoredBy
+      } else {
+        // Explicitly set to false to disable
+        settings.includeCoAuthoredBy = false
+      }
+
+      await writeClaudeSettings(settings)
+      return { success: true }
+    }),
+})

--- a/src/main/lib/trpc/routers/index.ts
+++ b/src/main/lib/trpc/routers/index.ts
@@ -3,6 +3,7 @@ import { projectsRouter } from "./projects"
 import { chatsRouter } from "./chats"
 import { claudeRouter } from "./claude"
 import { claudeCodeRouter } from "./claude-code"
+import { claudeSettingsRouter } from "./claude-settings"
 import { ollamaRouter } from "./ollama"
 import { terminalRouter } from "./terminal"
 import { externalRouter } from "./external"
@@ -25,6 +26,7 @@ export function createAppRouter(getWindow: () => BrowserWindow | null) {
     chats: chatsRouter,
     claude: claudeRouter,
     claudeCode: claudeCodeRouter,
+    claudeSettings: claudeSettingsRouter,
     ollama: ollamaRouter,
     terminal: terminalRouter,
     external: externalRouter,

--- a/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
@@ -15,6 +15,7 @@ import {
   SelectTrigger,
 } from "../../ui/select"
 import { Switch } from "../../ui/switch"
+import { trpc } from "../../../lib/trpc"
 
 // Hook to detect narrow screen
 function useIsNarrowScreen(): boolean {
@@ -41,6 +42,20 @@ export function AgentsPreferencesTab() {
   const [analyticsOptOut, setAnalyticsOptOut] = useAtom(analyticsOptOutAtom)
   const [ctrlTabTarget, setCtrlTabTarget] = useAtom(ctrlTabTargetAtom)
   const isNarrowScreen = useIsNarrowScreen()
+
+  // Co-authored-by setting from Claude settings.json
+  const { data: includeCoAuthoredBy, refetch: refetchCoAuthoredBy } =
+    trpc.claudeSettings.getIncludeCoAuthoredBy.useQuery()
+  const setCoAuthoredByMutation =
+    trpc.claudeSettings.setIncludeCoAuthoredBy.useMutation({
+      onSuccess: () => {
+        refetchCoAuthoredBy()
+      },
+    })
+
+  const handleCoAuthoredByToggle = (enabled: boolean) => {
+    setCoAuthoredByMutation.mutate({ enabled })
+  }
 
   // Sync opt-out status to main process
   const handleAnalyticsToggle = async (optedOut: boolean) => {
@@ -97,6 +112,28 @@ export function AgentsPreferencesTab() {
               </span>
             </div>
             <Switch checked={soundEnabled} onCheckedChange={setSoundEnabled} />
+          </div>
+        </div>
+      </div>
+
+      {/* Git Section */}
+      <div className="bg-background rounded-lg border border-border overflow-hidden">
+        <div className="p-4 space-y-6">
+          {/* Co-Authored-By Toggle */}
+          <div className="flex items-start justify-between">
+            <div className="flex flex-col space-y-1">
+              <span className="text-sm font-medium text-foreground">
+                Include Co-Authored-By
+              </span>
+              <span className="text-xs text-muted-foreground">
+                Add "Co-authored-by: Claude" to git commits made by Claude
+              </span>
+            </div>
+            <Switch
+              checked={includeCoAuthoredBy ?? true}
+              onCheckedChange={handleCoAuthoredByToggle}
+              disabled={setCoAuthoredByMutation.isPending}
+            />
           </div>
         </div>
       </div>

--- a/src/renderer/lib/atoms/index.ts
+++ b/src/renderer/lib/atoms/index.ts
@@ -364,6 +364,15 @@ export const analyticsOptOutAtom = atomWithStorage<boolean>(
   { getOnInit: true },
 )
 
+// Preferences - Disable Co-Authored-By Attribution
+// When true, Claude will not add "Co-authored-by: Claude" to git commits
+export const disableCoAuthoredByAtom = atomWithStorage<boolean>(
+  "preferences:disable-coauthored-by",
+  false, // Default to false (keep co-authored-by attribution)
+  undefined,
+  { getOnInit: true },
+)
+
 // Beta: Enable git features in diff sidebar (commit, staging, file selection)
 // When enabled, shows checkboxes for file selection and commit UI in diff sidebar
 // When disabled, shows simple file list with "Create PR" button


### PR DESCRIPTION
## Summary
- Adds a toggle in **Settings > Preferences** to control whether Claude adds "Co-authored-by: Claude" to git commits
- The setting is stored in `~/.claude/settings.json` using the standard `includeCoAuthoredBy` option that Claude Code respects
- Toggle is ON by default (co-authored-by is included), users can disable it if they prefer clean commit histories

## Changes
- New tRPC router (`claudeSettings`) with endpoints to read/write the `includeCoAuthoredBy` setting
- New "Git" section in Preferences tab with the toggle
- Uses Claude Code's native settings file so the preference works consistently

## Test plan
- [x] Open Settings > Preferences
- [x] Toggle "Include Co-Authored-By" off
- [x] Verify `~/.claude/settings.json` contains `"includeCoAuthoredBy": false`
- [x] Have Claude make a commit and verify no co-authored-by line
- [x] Toggle back on and verify the setting is removed from settings.json (uses default)