### PR TITLE
Fix Claude SDK spawn errors and handle expired sessions

### DIFF
--- a/src/renderer/features/agents/lib/ipc-chat-transport.ts
+++ b/src/renderer/features/agents/lib/ipc-chat-transport.ts
@@ -82,6 +82,11 @@ const ERROR_TOAST_CONFIG: Record<
     description:
       "The Claude process exited unexpectedly. Try sending your message again or rollback.",
   },
+  SESSION_EXPIRED: {
+    title: "Session expired",
+    description:
+      "Your previous chat session expired. Send your message again to start fresh.",
+  },
   EXECUTABLE_NOT_FOUND: {
     title: "Claude CLI not found",
     description:


### PR DESCRIPTION
## Summary

- Fix "spawn node ENOENT" error during MCP warmup by adding missing `pathToClaudeCodeExecutable` option
- Handle expired session gracefully by detecting "No conversation found" error and clearing invalid session ID

## Problem

1. **MCP Warmup Failure**: The `warmupMcpCache()` function was missing the `pathToClaudeCodeExecutable` option, causing the SDK to fall back to spawning via `node` which isn't in PATH when the app is launched from GUI (desktop shortcut/app menu).

2. **Session Crash**: When resuming a chat session that no longer exists in Claude CLI's storage (e.g., after CLI update or session expiry), the process would crash with "No conversation found with session ID" error, showing a confusing "Claude crashed" message to users.

## Solution

1. Added `pathToClaudeCodeExecutable: getBundledClaudeBinaryPath()` to the warmup query options, matching what the chat function already does.

2. Added detection for the session-not-found error in stderr. When detected:
   - Clears the invalid `sessionId` from the database
   - Returns a user-friendly "SESSION_EXPIRED" error category
   - Shows "Session expired - send your message again to start fresh" toast

## Test plan

- [ ] Launch app from GUI (not terminal) - MCP warmup should not show "spawn node ENOENT" errors
- [ ] With an existing chat that has a stale session ID, send a message - should show "Session expired" toast and work on retry