### PR TITLE
Fix Windows compatibility for git worktree operations

### DIFF
--- a/src/main/lib/git/shell-env.ts
+++ b/src/main/lib/git/shell-env.ts
@@ -36,6 +36,20 @@ export async function getShellEnvironment(): Promise<Record<string, string>> {
 		return { ...cachedEnv };
 	}
 
+	// On Windows, use process.env directly (no Unix shell available)
+	if (process.platform === "win32") {
+		const fallback: Record<string, string> = {};
+		for (const [key, value] of Object.entries(process.env)) {
+			if (typeof value === "string") {
+				fallback[key] = value;
+			}
+		}
+		cachedEnv = fallback;
+		cacheTime = now;
+		isFallbackCache = false;
+		return { ...fallback };
+	}
+
 	const shell =
 		process.env.SHELL ||
 		(process.platform === "darwin" ? "/bin/zsh" : "/bin/bash");

--- a/src/main/lib/git/worktree-config.ts
+++ b/src/main/lib/git/worktree-config.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir, access } from "node:fs/promises"
-import { join, dirname } from "node:path"
+import { join, dirname, isAbsolute } from "node:path"
 import { exec } from "node:child_process"
 import { promisify } from "node:util"
 
@@ -50,7 +50,7 @@ export async function detectWorktreeConfig(
 ): Promise<DetectedWorktreeConfig> {
   // 1. Check custom path if provided
   if (customPath) {
-    const fullPath = customPath.startsWith("/")
+    const fullPath = isAbsolute(customPath)
       ? customPath
       : join(projectPath, customPath)
     const config = await readJsonFile<WorktreeConfig>(fullPath)
@@ -122,7 +122,7 @@ export async function saveWorktreeConfig(
     targetPath = join(projectPath, ONECODE_CONFIG_PATH)
   } else {
     // Custom path
-    targetPath = target.startsWith("/") ? target : join(projectPath, target)
+    targetPath = isAbsolute(target) ? target : join(projectPath, target)
   }
 
   try {


### PR DESCRIPTION
- Add Windows platform check in getShellEnvironment() to avoid spawning Unix shells (/bin/bash, /bin/zsh) which don't exist on Windows
- Replace hardcoded "/dev/null" with os.devNull for cross-platform compatibility in git diff --no-index commands
- Pre-resolve git refs to commit hashes before passing to execFile to avoid Windows command line escaping issues with ^{commit} syntax
- Fallback to local branch when origin/branch doesn't exist
- Use path.isAbsolute() instead of startsWith("/") for cross-platform absolute path detection in worktree-config.ts