### PR TITLE
fix: update Claude binary version fetch to use GCS bucket endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "21st-desktop",

--- a/scripts/download-claude-binary.mjs
+++ b/scripts/download-claude-binary.mjs
@@ -127,27 +127,24 @@ function calculateSha256(filePath) {
 }
 
 /**
- * Get latest version from manifest
+ * Get latest version from GCS bucket
  */
 async function getLatestVersion() {
-  // Try to fetch version list or use known latest
-  // For now, we'll fetch the manifest for a known version
   console.log("Fetching latest Claude Code version...")
 
   try {
-    // The install script endpoint returns version info
-    const response = await fetch("https://claude.ai/install.sh")
-    const script = await response.text()
-    const versionMatch = script.match(/CLAUDE_CODE_VERSION="([^"]+)"/)
-    if (versionMatch) {
-      return versionMatch[1]
+    // Fetch from the same endpoint that install.sh uses
+    const response = await fetch("https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/latest")
+    if (response.ok) {
+      const version = await response.text()
+      return version.trim()
     }
-  } catch {
-    // Fallback
+  } catch (error) {
+    console.warn(`Failed to fetch latest version: ${error.message}`)
   }
 
-  // Fallback to known version
-  return "2.1.5"
+  // Fallback to known version (should be updated periodically)
+  return "2.1.17"
 }
 
 /**


### PR DESCRIPTION
The previous implementation tried to parse version from install.sh script by matching CLAUDE_CODE_VERSION variable, but this method is outdated and no longer works, causing the script to fallback to hardcoded 2.1.5.

Now fetches version directly from the same GCS bucket endpoint that official install.sh uses, ensuring we always get the latest version.

- Updated fallback version from 2.1.5 to 2.1.17
- Changed fetch URL from install.sh to GCS bucket latest endpoint
- Improved error logging with specific error messages