### PR TITLE
feat(desktop): add export/copy chat to context menus

### DIFF
--- a/src/main/lib/trpc/routers/chats.ts
+++ b/src/main/lib/trpc/routers/chats.ts
@@ -1638,4 +1638,312 @@ export const chatsRouter = router({
         return { hasWorktree: false, uncommittedCount: 0 }
       }
     }),
+
+  /**
+   * Export a chat conversation to various formats.
+   * Supports exporting entire workspace or a single sub-chat.
+   * Useful for sharing, backup, or importing into other tools.
+   */
+  exportChat: publicProcedure
+    .input(
+      z.object({
+        chatId: z.string(),
+        subChatId: z.string().optional(), // If provided, export only this sub-chat
+        format: z.enum(["json", "markdown", "text"]).default("markdown"),
+      }),
+    )
+    .query(async ({ input }) => {
+      const db = getDatabase()
+      const chat = db
+        .select()
+        .from(chats)
+        .where(eq(chats.id, input.chatId))
+        .get()
+
+      if (!chat) {
+        throw new Error("Chat not found")
+      }
+
+      const project = db
+        .select()
+        .from(projects)
+        .where(eq(projects.id, chat.projectId))
+        .get()
+
+      // Query sub-chats: either a specific one or all for the chat
+      let chatSubChats
+      if (input.subChatId) {
+        // Export single sub-chat
+        const singleSubChat = db
+          .select()
+          .from(subChats)
+          .where(and(
+            eq(subChats.id, input.subChatId),
+            eq(subChats.chatId, input.chatId) // Ensure sub-chat belongs to this chat
+          ))
+          .get()
+
+        if (!singleSubChat) {
+          throw new Error("Sub-chat not found")
+        }
+        chatSubChats = [singleSubChat]
+      } else {
+        // Export all sub-chats
+        chatSubChats = db
+          .select()
+          .from(subChats)
+          .where(eq(subChats.chatId, input.chatId))
+          .orderBy(subChats.createdAt)
+          .all()
+      }
+
+      // parse messages from sub-chats
+      const allMessages: Array<{
+        subChatId: string
+        subChatName: string | null
+        messages: Array<{
+          id: string
+          role: string
+          parts: Array<{ type: string; text?: string; [key: string]: any }>
+          metadata?: any
+        }>
+      }> = []
+
+      for (const subChat of chatSubChats) {
+        try {
+          const messages = JSON.parse(subChat.messages || "[]")
+          allMessages.push({
+            subChatId: subChat.id,
+            subChatName: subChat.name,
+            messages,
+          })
+        } catch {
+          // skip invalid json
+        }
+      }
+
+      // Sanitize filename - remove characters that are invalid on Windows/macOS/Linux
+      const sanitizeFilename = (name: string): string => {
+        return name
+          .replace(/[<>:"/\\|?*\x00-\x1F]/g, "_") // Invalid chars
+          .replace(/\s+/g, "_") // Replace spaces with underscores
+          .replace(/_+/g, "_") // Collapse multiple underscores
+          .replace(/^_|_$/g, "") // Trim underscores from ends
+          .slice(0, 100) // Limit length
+          || "chat" // Fallback if empty
+      }
+
+      // Use sub-chat name if exporting single sub-chat, otherwise use chat name
+      const exportName = input.subChatId && chatSubChats[0]?.name
+        ? `${chat.name || "chat"}-${chatSubChats[0].name}`
+        : (chat.name || "chat")
+      const safeFilename = sanitizeFilename(exportName)
+
+      if (input.format === "json") {
+        return {
+          format: "json" as const,
+          content: JSON.stringify(
+            {
+              exportedAt: new Date().toISOString(),
+              chat: {
+                id: chat.id,
+                name: chat.name,
+                createdAt: chat.createdAt,
+                branch: chat.branch,
+                baseBranch: chat.baseBranch,
+                prUrl: chat.prUrl,
+              },
+              project: project
+                ? {
+                    id: project.id,
+                    name: project.name,
+                    path: project.path,
+                  }
+                : null,
+              conversations: allMessages,
+            },
+            null,
+            2,
+          ),
+          filename: `${safeFilename}-${chat.id.slice(0, 8)}.json`,
+        }
+      }
+
+      if (input.format === "text") {
+        // plain text format
+        let text = `# ${chat.name || "Untitled Chat"}\n`
+        text += `exported: ${new Date().toISOString()}\n`
+        if (project) {
+          text += `project: ${project.name}\n`
+        }
+        text += `\n---\n\n`
+
+        for (const subChatData of allMessages) {
+          if (subChatData.subChatName) {
+            text += `## ${subChatData.subChatName}\n\n`
+          }
+
+          for (const msg of subChatData.messages) {
+            const role = msg.role === "user" ? "You" : "Assistant"
+            text += `${role}:\n`
+
+            for (const part of msg.parts || []) {
+              if (part.type === "text" && part.text) {
+                text += `${part.text}\n`
+              } else if (part.type?.startsWith("tool-") && part.toolName) {
+                text += `[used ${part.toolName} tool]\n`
+              }
+            }
+            text += "\n"
+          }
+        }
+
+        return {
+          format: "text" as const,
+          content: text,
+          filename: `${safeFilename}-${chat.id.slice(0, 8)}.txt`,
+        }
+      }
+
+      // markdown format (default)
+      let markdown = `# ${chat.name || "Untitled Chat"}\n\n`
+      markdown += `**Exported:** ${new Date().toISOString()}\n\n`
+      if (project) {
+        markdown += `**Project:** ${project.name}\n\n`
+      }
+      if (chat.branch) {
+        markdown += `**Branch:** \`${chat.branch}\`\n\n`
+      }
+      if (chat.prUrl) {
+        markdown += `**PR:** [${chat.prUrl}](${chat.prUrl})\n\n`
+      }
+      markdown += `---\n\n`
+
+      for (const subChatData of allMessages) {
+        if (subChatData.subChatName) {
+          markdown += `## ${subChatData.subChatName}\n\n`
+        }
+
+        for (const msg of subChatData.messages) {
+          const role = msg.role === "user" ? "**You**" : "**Assistant**"
+          markdown += `### ${role}\n\n`
+
+          for (const part of msg.parts || []) {
+            if (part.type === "text" && part.text) {
+              markdown += `${part.text}\n\n`
+            } else if (part.type?.startsWith("tool-") && part.toolName) {
+              const toolName = part.toolName
+              if (toolName === "Bash" && part.input?.command) {
+                markdown += `\`\`\`bash\n${part.input.command}\n\`\`\`\n\n`
+              } else if (
+                (toolName === "Edit" || toolName === "Write") &&
+                part.input?.file_path
+              ) {
+                markdown += `> Modified: \`${part.input.file_path}\`\n\n`
+              } else if (toolName === "Read" && part.input?.file_path) {
+                markdown += `> Read: \`${part.input.file_path}\`\n\n`
+              } else {
+                markdown += `> *Used ${toolName} tool*\n\n`
+              }
+            }
+          }
+        }
+      }
+
+      return {
+        format: "markdown" as const,
+        content: markdown,
+        filename: `${safeFilename}-${chat.id.slice(0, 8)}.md`,
+      }
+    }),
+
+  /**
+   * Get basic stats for a chat (message count, tool usage, etc.)
+   * Supports both full chat stats and individual sub-chat stats.
+   * Useful for showing chat summary in sidebar or export dialogs.
+   */
+  getChatStats: publicProcedure
+    .input(z.object({
+      chatId: z.string(),
+      subChatId: z.string().optional(), // If provided, return stats for only this sub-chat
+    }))
+    .query(({ input }) => {
+      const db = getDatabase()
+
+      let chatSubChats
+      if (input.subChatId) {
+        // Get stats for a single sub-chat
+        const singleSubChat = db
+          .select()
+          .from(subChats)
+          .where(and(
+            eq(subChats.id, input.subChatId),
+            eq(subChats.chatId, input.chatId)
+          ))
+          .get()
+
+        chatSubChats = singleSubChat ? [singleSubChat] : []
+      } else {
+        // Get stats for all sub-chats
+        chatSubChats = db
+          .select()
+          .from(subChats)
+          .where(eq(subChats.chatId, input.chatId))
+          .all()
+      }
+
+      let messageCount = 0
+      let userMessageCount = 0
+      let assistantMessageCount = 0
+      let toolCalls = 0
+      const toolUsage: Record<string, number> = {}
+      let totalInputTokens = 0
+      let totalOutputTokens = 0
+
+      for (const subChat of chatSubChats) {
+        try {
+          const messages = JSON.parse(subChat.messages || "[]") as Array<{
+            role: string
+            parts?: Array<{ type: string; toolName?: string }>
+            metadata?: { usage?: { inputTokens?: number; outputTokens?: number } }
+          }>
+
+          for (const msg of messages) {
+            messageCount++
+            if (msg.role === "user") {
+              userMessageCount++
+            } else if (msg.role === "assistant") {
+              assistantMessageCount++
+
+              // count tool calls
+              for (const part of msg.parts || []) {
+                if (part.type?.startsWith("tool-") && part.toolName) {
+                  toolCalls++
+                  toolUsage[part.toolName] = (toolUsage[part.toolName] || 0) + 1
+                }
+              }
+
+              // aggregate token usage
+              if (msg.metadata?.usage) {
+                totalInputTokens += msg.metadata.usage.inputTokens || 0
+                totalOutputTokens += msg.metadata.usage.outputTokens || 0
+              }
+            }
+          }
+        } catch {
+          // skip invalid json
+        }
+      }
+
+      return {
+        messageCount,
+        userMessageCount,
+        assistantMessageCount,
+        toolCalls,
+        toolUsage,
+        totalInputTokens,
+        totalOutputTokens,
+        subChatCount: chatSubChats.length,
+      }
+    }),
 })

--- a/src/renderer/features/agents/lib/export-chat.ts
+++ b/src/renderer/features/agents/lib/export-chat.ts
@@ -1,0 +1,74 @@
+import { trpcClient } from "../../../lib/trpc"
+import { toast } from "sonner"
+
+export type ExportFormat = "markdown" | "json" | "text"
+
+interface ExportOptions {
+  chatId: string
+  subChatId?: string
+  format: ExportFormat
+}
+
+/**
+ * Export a chat or sub-chat to a file.
+ * Shows download dialog to save the exported content.
+ */
+export async function exportChat({ chatId, subChatId, format }: ExportOptions): Promise<void> {
+  try {
+    const exportData = await trpcClient.chats.exportChat.query({
+      chatId,
+      subChatId,
+      format,
+    })
+
+    const blob = new Blob([exportData.content], { type: "text/plain;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = exportData.filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+
+    toast.success("Export complete", {
+      description: `Saved as ${exportData.filename}`,
+    })
+  } catch (error) {
+    console.error("[exportChat] Error:", error)
+    toast.error("Export failed", {
+      description: error instanceof Error ? error.message : "Unable to export chat",
+    })
+  }
+}
+
+/**
+ * Copy chat or sub-chat content to clipboard.
+ */
+export async function copyChat({ chatId, subChatId, format }: ExportOptions): Promise<void> {
+  try {
+    const exportData = await trpcClient.chats.exportChat.query({
+      chatId,
+      subChatId,
+      format,
+    })
+
+    try {
+      await navigator.clipboard.writeText(exportData.content)
+    } catch {
+      // Fallback using Electron clipboard API
+      if (window.desktopApi?.clipboardWrite) {
+        await window.desktopApi.clipboardWrite(exportData.content)
+      } else {
+        throw new Error("Clipboard not available")
+      }
+    }
+
+    toast.success("Copied to clipboard")
+  } catch (error) {
+    console.error("[copyChat] Error:", error)
+    toast.error("Copy failed", {
+      description: error instanceof Error ? error.message : "Unable to copy chat",
+    })
+  }
+}

--- a/src/renderer/features/agents/ui/sub-chat-context-menu.tsx
+++ b/src/renderer/features/agents/ui/sub-chat-context-menu.tsx
@@ -1,13 +1,17 @@
-import React, { useMemo } from "react"
+import React, { useMemo, useCallback } from "react"
 import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
 } from "../../../components/ui/context-menu"
 import { Kbd } from "../../../components/ui/kbd"
 import { isMac } from "../../../lib/utils"
 import type { SubChatMeta } from "../stores/sub-chat-store"
 import { getShortcutKey } from "../../../lib/utils/platform"
+import { exportChat, copyChat, type ExportFormat } from "../lib/export-chat"
 
 // Platform-aware keyboard shortcut
 // Web: ⌥⌘W (browser uses Cmd+W to close tab)
@@ -37,6 +41,8 @@ interface SubChatContextMenuProps {
   visualIndex?: number
   hasTabsToRight?: boolean
   canCloseOtherTabs?: boolean
+  /** Parent chat ID for export functionality */
+  chatId?: string | null
 }
 
 export function SubChatContextMenu({
@@ -57,8 +63,19 @@ export function SubChatContextMenu({
   visualIndex = 0,
   hasTabsToRight = false,
   canCloseOtherTabs = false,
+  chatId,
 }: SubChatContextMenuProps) {
   const closeTabShortcut = useCloseTabShortcut()
+
+  const handleExport = useCallback((format: ExportFormat) => {
+    if (!chatId) return
+    exportChat({ chatId, subChatId: subChat.id, format })
+  }, [chatId, subChat.id])
+
+  const handleCopy = useCallback((format: ExportFormat) => {
+    if (!chatId) return
+    copyChat({ chatId, subChatId: subChat.id, format })
+  }, [chatId, subChat.id])
 
   return (
     <ContextMenuContent className="w-48">
@@ -68,6 +85,32 @@ export function SubChatContextMenu({
       <ContextMenuItem onClick={() => onRename(subChat)}>
         Rename chat
       </ContextMenuItem>
+      {chatId && (
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>Export chat</ContextMenuSubTrigger>
+          <ContextMenuSubContent sideOffset={6} alignOffset={-4}>
+            <ContextMenuItem onClick={() => handleExport("markdown")}>
+              Download as Markdown
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => handleExport("json")}>
+              Download as JSON
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => handleExport("text")}>
+              Download as Text
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem onClick={() => handleCopy("markdown")}>
+              Copy as Markdown
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => handleCopy("json")}>
+              Copy as JSON
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => handleCopy("text")}>
+              Copy as Text
+            </ContextMenuItem>
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+      )}
       <ContextMenuSeparator />
 
       {showCloseTabOptions ? (

--- a/src/renderer/features/agents/ui/sub-chat-selector.tsx
+++ b/src/renderer/features/agents/ui/sub-chat-selector.tsx
@@ -811,6 +811,7 @@ export function SubChatSelector({
                       visualIndex={index}
                       hasTabsToRight={hasTabsToRight}
                       canCloseOtherTabs={openSubChats.length > 2}
+                      chatId={parentChatId}
                     />
                   </ContextMenu>
                 )

--- a/src/renderer/features/sidebar/agents-sidebar.tsx
+++ b/src/renderer/features/sidebar/agents-sidebar.tsx
@@ -60,6 +60,9 @@ import {
   ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
 } from "../../components/ui/context-menu"
 import {
   IconDoubleChevronLeft,
@@ -108,6 +111,7 @@ import { useHotkeys } from "react-hotkeys-hook"
 import { Checkbox } from "../../components/ui/checkbox"
 import { useHaptic } from "./hooks/use-haptic"
 import { TypewriterText } from "../../components/ui/typewriter-text"
+import { exportChat, copyChat, type ExportFormat } from "../agents/lib/export-chat"
 
 // Feedback URL: uses env variable for hosted version, falls back to public Discord for open source
 const FEEDBACK_URL =
@@ -687,6 +691,30 @@ const AgentChatItem = React.memo(function AgentChatItem({
                 Copy branch name
               </ContextMenuItem>
             )}
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>Export workspace</ContextMenuSubTrigger>
+              <ContextMenuSubContent sideOffset={6} alignOffset={-4}>
+                <ContextMenuItem onClick={() => exportChat({ chatId, format: "markdown" })}>
+                  Download as Markdown
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => exportChat({ chatId, format: "json" })}>
+                  Download as JSON
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => exportChat({ chatId, format: "text" })}>
+                  Download as Text
+                </ContextMenuItem>
+                <ContextMenuSeparator />
+                <ContextMenuItem onClick={() => copyChat({ chatId, format: "markdown" })}>
+                  Copy as Markdown
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => copyChat({ chatId, format: "json" })}>
+                  Copy as JSON
+                </ContextMenuItem>
+                <ContextMenuItem onClick={() => copyChat({ chatId, format: "text" })}>
+                  Copy as Text
+                </ContextMenuItem>
+              </ContextMenuSubContent>
+            </ContextMenuSub>
             <ContextMenuSeparator />
             <ContextMenuItem onClick={() => onArchive(chatId)} className="justify-between">
               Archive workspace

--- a/src/renderer/features/sidebar/agents-subchats-sidebar.tsx
+++ b/src/renderer/features/sidebar/agents-subchats-sidebar.tsx
@@ -1426,6 +1426,7 @@ export function AgentsSubChatsSidebar({
                                   isOnlyChat={openSubChats.length === 1}
                                   currentIndex={globalIndex}
                                   totalCount={filteredSubChats.length}
+                                  chatId={parentChatId}
                                 />
                               )}
                             </ContextMenu>
@@ -1699,6 +1700,7 @@ export function AgentsSubChatsSidebar({
                                   isOnlyChat={openSubChats.length === 1}
                                   currentIndex={globalIndex}
                                   totalCount={filteredSubChats.length}
+                                  chatId={parentChatId}
                                 />
                               )}
                             </ContextMenu>


### PR DESCRIPTION
## Summary
- Add export submenu to sub-chat context menu with download/copy options
- Add export submenu to workspace context menu with download/copy options  
- Support Markdown, JSON, and Plain Text formats
- Backend: add `subChatId` parameter to `exportChat` and `getChatStats` endpoints for individual sub-chat export

## Test plan
- [ ] Right-click on a sub-chat tab → Export chat → verify download/copy options work
- [ ] Right-click on a workspace in sidebar → Export workspace → verify download/copy options work
- [ ] Verify exported content includes all messages and tool calls
- [ ] Test copy to clipboard functionality

🤖 Generated with [Claude Code](https://claude.ai/code)