### PR TITLE
fix: custom slash commands silently fail with multi-line arguments

### DIFF
--- a/src/renderer/features/agents/main/new-chat-form.tsx
+++ b/src/renderer/features/agents/main/new-chat-form.tsx
@@ -776,7 +776,8 @@ export function NewChatForm({
     }
 
     // Check if message is a slash command with arguments (e.g. "/hello world")
-    const slashMatch = message.match(/^\/(\S+)\s*(.*)$/)
+    // Note: 's' flag makes '.' match newlines, so multi-line arguments are captured
+    const slashMatch = message.match(/^\/(\S+)\s*(.*)$/s)
     if (slashMatch) {
       const [, commandName, args] = slashMatch
 
@@ -790,7 +791,7 @@ export function NewChatForm({
           const commands = await trpcUtils.commands.list.fetch({
             projectPath: validatedProject?.path,
           })
-          const cmd = commands.find((c) => c.name === commandName)
+          const cmd = commands.find((c) => c.name.toLowerCase() === commandName.toLowerCase())
 
           if (cmd) {
             const { content } = await trpcUtils.commands.getContent.fetch({


### PR DESCRIPTION
## Critical Bug: Custom slash commands completely broken with multi-line arguments

Custom slash commands (from `~/.claude/commands/`) **silently fail** when the user provides arguments that contain newlines. The AI shows its "thinking" indicator for ~0.5 seconds, then stops — **no response, no error message, nothing**. The user has no way to know what went wrong.

This is a **blocking issue** for anyone using custom commands with non-trivial prompts. As soon as the argument spans more than one line (which is common when pasting code snippets, multi-line instructions, or long prompts), the command is completely broken.

### How to reproduce

1. Create a custom command at `~/.claude/commands/MyCommand.md`:
   ```markdown
   ---
   argument-hint: your input
   ---
   Do something with: $ARGUMENTS
   ```
2. In 1Code, type `/MyCommand` followed by a **multi-line** argument (paste multiple lines of text)
3. Send the message
4. **Result**: The AI indicator appears briefly (~0.5s), then disappears. No response, no error. Nothing happens.
5. **Expected**: The command should expand `$ARGUMENTS` with the multi-line text and send the full prompt to Claude.

> **Note**: It works perfectly fine with short, single-line arguments. Only multi-line arguments trigger the silent failure.

### Root Cause

**Two bugs found:**

#### Bug 1 — Regex missing `s` (dotAll) flag in `new-chat-form.tsx`

The regex used to parse slash command arguments:
```js
message.match(/^\/(\S+)\s*(.*)$/)
```
Without the `s` flag, `.` does **not** match `\n` (newline characters). So when the argument contains newlines, `(.*)` stops at the first newline and the regex fails entirely — the command is never expanded, and the raw `/MyCommand <text>` is sent to the Claude SDK, which returns an empty result.

**Fix**: Add the `s` flag → `/^\/(\S+)\s*(.*)$/s`

#### Bug 2 — `active-chat.tsx` entirely missing slash command expansion

`new-chat-form.tsx` (new chats) had the expansion logic for `$ARGUMENTS`, but `active-chat.tsx` (existing chat sessions) had **none at all**. Custom slash commands with arguments never worked in ongoing conversations — only in the first message of a new chat.

**Fix**: Add the same expansion logic to both `handleSend` and `handleForceSend` in `active-chat.tsx`.

#### Bonus — Case-sensitive command matching

Command matching was case-sensitive (`/mycommand` wouldn't match `MyCommand.md`), which is inconsistent with how the CLI handles slash commands.

**Fix**: Use `.toLowerCase()` for comparison.

### Changes

| File | Change |
|------|--------|
| `new-chat-form.tsx` | Add `s` flag to regex + case-insensitive matching |
| `active-chat.tsx` | Add missing slash command expansion in `handleSend` + `handleForceSend` |

### Impact

- **Before**: Any custom command with multi-line arguments silently fails (no response, no error)
- **After**: Custom commands work correctly regardless of argument length or newlines

This is a minimal, focused fix — only the 2 files directly involved in the bug are touched.

### Test plan

- [ ] Create a custom command with `$ARGUMENTS` placeholder
- [ ] Send `/command` with a **single-line** argument → should work (regression check)
- [ ] Send `/command` with a **multi-line** argument → should now work
- [ ] Send `/command` in a **new chat** → should work
- [ ] Send `/command` in an **existing chat session** → should now work
- [ ] Verify case-insensitive matching (`/mycommand` matches `MyCommand.md`)
- [ ] Verify built-in commands (`/plan`, `/agent`, `/clear`) are unaffected