### PR TITLE
feat: improve terminal copy/paste support on Windows

### DIFF
--- a/src/renderer/features/terminal/helpers.ts
+++ b/src/renderer/features/terminal/helpers.ts
@@ -205,6 +205,7 @@ export interface KeyboardHandlerOptions {
  * Setup keyboard handling for xterm including:
  * - Shift+Enter: Sends ESC+CR sequence
  * - Cmd+K: Clear terminal
+ * - Ctrl+V / Cmd+V: Intercept to allow browser paste event
  *
  * Returns a cleanup function to remove the handler.
  */
@@ -237,6 +238,19 @@ export function setupKeyboardHandler(
         options.onClear()
       }
       return false // Prevent xterm from processing
+    }
+
+    // Ctrl+V (Windows/Linux) or Cmd+V (macOS) - let Electron menu handle paste
+    // Return false to prevent xterm from showing ^v character
+    // The Electron menu's "paste" role will trigger a paste event on the textarea
+    const isPasteShortcut =
+      event.key === "v" &&
+      !event.shiftKey &&
+      !event.altKey &&
+      (isMac() ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey)
+
+    if (isPasteShortcut) {
+      return false // Prevent xterm from showing ^v, let Electron menu handle it
     }
 
     return true // Let xterm process the key
@@ -418,5 +432,59 @@ export function setupClickToMoveCursor(
 
   return () => {
     xterm.element?.removeEventListener("click", handleClick)
+  }
+}
+
+export interface ContextMenuHandlerOptions {
+  /** Callback when text is copied via context menu */
+  onCopy?: (text: string) => void
+  /** Callback when text is pasted via context menu */
+  onPaste?: (text: string) => void
+}
+
+/**
+ * Setup right-click context menu for terminal with copy/paste support.
+ * - If text is selected: copies to clipboard
+ * - If no selection: pastes from clipboard
+ *
+ * Returns a cleanup function to remove the handler.
+ */
+export function setupContextMenuHandler(
+  xterm: XTerm,
+  options: ContextMenuHandlerOptions = {}
+): () => void {
+  const handleContextMenu = async (event: MouseEvent) => {
+    event.preventDefault()
+
+    const selection = xterm.getSelection()
+
+    if (selection) {
+      // Has selection - copy to clipboard
+      try {
+        await navigator.clipboard.writeText(selection)
+        options.onCopy?.(selection)
+        // Clear selection after copy (optional, mimics typical terminal behavior)
+        xterm.clearSelection()
+      } catch (err) {
+        console.warn("[Terminal] Failed to copy to clipboard:", err)
+      }
+    } else {
+      // No selection - paste from clipboard
+      try {
+        const text = await navigator.clipboard.readText()
+        if (text) {
+          options.onPaste?.(text)
+          xterm.paste(text)
+        }
+      } catch (err) {
+        console.warn("[Terminal] Failed to paste from clipboard:", err)
+      }
+    }
+  }
+
+  xterm.element?.addEventListener("contextmenu", handleContextMenu)
+
+  return () => {
+    xterm.element?.removeEventListener("contextmenu", handleContextMenu)
   }
 }

--- a/src/renderer/features/terminal/terminal.tsx
+++ b/src/renderer/features/terminal/terminal.tsx
@@ -5,6 +5,7 @@ import type { SearchAddon } from "@xterm/addon-search"
 import type { SerializeAddon } from "@xterm/addon-serialize"
 import { useTheme } from "next-themes"
 import { useSetAtom, useAtomValue } from "jotai"
+import { toast } from "sonner"
 import { trpc } from "@/lib/trpc"
 import { terminalCwdAtom } from "./atoms"
 import { fullThemeDataAtom } from "@/lib/atoms"
@@ -12,6 +13,7 @@ import {
   createTerminalInstance,
   getDefaultTerminalBg,
   setupClickToMoveCursor,
+  setupContextMenuHandler,
   setupFocusListener,
   setupKeyboardHandler,
   setupPasteHandler,
@@ -304,6 +306,15 @@ export function Terminal({
       },
     })
 
+    const cleanupContextMenu = setupContextMenuHandler(xterm, {
+      onCopy: () => {
+        toast.success("Copied to clipboard")
+      },
+      onPaste: (text) => {
+        commandBufferRef.current += text
+      },
+    })
+
     // Cleanup on unmount
     return () => {
       console.log("[Terminal:useEffect] UNMOUNT - paneId:", paneId)
@@ -315,6 +326,7 @@ export function Terminal({
       cleanupFocus?.()
       cleanupResize()
       cleanupPaste()
+      cleanupContextMenu()
       cleanup()
 
       // Serialize terminal state before detaching


### PR DESCRIPTION
- Add right-click context menu for terminal with copy/paste support
  - If text is selected: copies to clipboard and shows toast notification
  - If no selection: pastes from clipboard
- Fix Ctrl+V paste by intercepting the key to prevent xterm showing ^v and letting Electron's menu paste role handle it via paste event
- Works on both Windows and macOS