### PR TITLE
feat: sort command autocomplete by name length for better UX

### DIFF
--- a/src/renderer/features/agents/commands/agents-slash-command.tsx
+++ b/src/renderer/features/agents/commands/agents-slash-command.tsx
@@ -134,7 +134,7 @@ export const AgentsSlashCommand = memo(function AgentsSlashCommand({
     }
 
     // Filter out disabled commands
-    if (disabledCommands && disabledCommands.length > 0) {
+    if (disabledCommands?.length) {
       builtinFiltered = builtinFiltered.filter(
         (cmd) => !disabledCommands.includes(cmd.name),
       )
@@ -151,8 +151,10 @@ export const AgentsSlashCommand = memo(function AgentsSlashCommand({
       )
     }
 
-    // Return custom commands first, then builtin
-    return [...customFiltered, ...builtinFiltered]
+    // Sort all commands by name length (shorter = closer match)
+    return [...customFiltered, ...builtinFiltered].sort(
+      (a, b) => a.name.length - b.name.length,
+    )
   }, [debouncedSearchText, customCommands, isPlanMode, disabledCommands])
 
   // Track previous values for smarter selection reset

--- a/src/renderer/features/agents/commands/builtin-commands.ts
+++ b/src/renderer/features/agents/commands/builtin-commands.ts
@@ -130,7 +130,8 @@ export const BUILTIN_SLASH_COMMANDS: SlashCommandOption[] = [
 ]
 
 /**
- * Filter builtin commands by search text
+ * Filter builtin commands by search text and sort by relevance
+ * Sorting: shorter command names first (closer match to what user typed)
  */
 export function filterBuiltinCommands(
   searchText: string,
@@ -142,5 +143,5 @@ export function filterBuiltinCommands(
     (cmd) =>
       cmd.name.toLowerCase().includes(query) ||
       cmd.description.toLowerCase().includes(query),
-  )
+  ).sort((a, b) => a.name.length - b.name.length)
 }


### PR DESCRIPTION
## Summary
- Sort slash command suggestions by name length (shortest first)
- When typing a prefix like "ape", `/apex` now appears before `/apex-analyze`
- Applies to both custom and builtin commands

## Test plan
- [ ] Type `/ape` and verify `apex` appears before longer variants like `apex-analyze`
- [ ] Verify all commands still appear when no search text is entered
- [ ] Verify filtering still works correctly (only matching commands show)

🤖 Generated with [Claude Code](https://claude.ai/code)