### PR TITLE
fix: fetch remote branch before creating worktree

### DIFF
--- a/src/main/lib/git/worktree.ts
+++ b/src/main/lib/git/worktree.ts
@@ -931,6 +931,15 @@ export async function createWorktreeForChat(
 		// For remote branches or when type is not specified, use origin/{branch}
 		const startPoint = branchType === "local" ? baseBranch : `origin/${baseBranch}`;
 
+		// For remote branches, fetch the latest from origin to ensure we have up-to-date refs
+		if (branchType === "remote") {
+			try {
+				await git.fetch("origin", baseBranch);
+			} catch (fetchError) {
+				console.warn(`[worktree] Failed to fetch origin/${baseBranch}, proceeding with local refs:`, fetchError);
+			}
+		}
+
 		await createWorktree(projectPath, branch, worktreePath, startPoint);
 
 		// Run worktree setup commands in BACKGROUND (don't block chat creation)


### PR DESCRIPTION
## Summary

- When creating a worktree from a **remote** branch, the app now fetches the latest refs from origin before creating the worktree
- This ensures that after merging a PR, new worktrees are based on the up-to-date state of the remote branch
- The fetch is wrapped in a try/catch for graceful offline fallback

## Problem

Previously, selecting "main (remote)" in the branch selector would use `origin/main` as it exists in the **local** repository. If a PR was merged on GitHub but the local repo hadn't run `git fetch`, the new worktree would be based on stale refs.

## Solution

Added a `git fetch origin {branchName}` call before worktree creation when `branchType === "remote"`.

## Test plan

- [ ] Create a worktree from a remote branch after merging a PR (without manually fetching)
- [ ] Verify the worktree contains the latest changes from the merged PR
- [ ] Test offline mode - should gracefully fall back to local refs

🤖 Generated with [Claude Code](https://claude.ai/code)