### PR TITLE
fix(sqlite): prevent sqlite migration crash on sub_chats drop columns

### DIFF
--- a/drizzle/0005_marvelous_master_chief.sql
+++ b/drizzle/0005_marvelous_master_chief.sql
@@ -1,4 +1,1 @@
-CREATE INDEX `chats_worktree_path_idx` ON `chats` (`worktree_path`);--> statement-breakpoint
-ALTER TABLE `sub_chats` DROP COLUMN `additions`;--> statement-breakpoint
-ALTER TABLE `sub_chats` DROP COLUMN `deletions`;--> statement-breakpoint
-ALTER TABLE `sub_chats` DROP COLUMN `file_count`;
+CREATE INDEX `chats_worktree_path_idx` ON `chats` (`worktree_path`);


### PR DESCRIPTION
### Context
On app startup Drizzle runs SQLite migrations from the bundled `migrations/` folder. In some DB states (fresh install / columns never created), migration `0005_marvelous_master_chief.sql` tries to drop `sub_chats` columns (`additions/deletions/file_count`), which causes:
`SQLITE_ERROR: no such column: ...`

Once this happens, migrations abort and the app can end up in a broken state.

Screenshot of the resulting UI error is attached below.
<img width="848" height="326" alt="image" src="https://github.com/user-attachments/assets/496b8e6d-3fb3-4b5c-9128-4ac4306f28df" />


This seems to come from PR #87 / commit 15ee551:
- Migration file: https://github.com/paul-bouzian/1code/blob/15ee55107f3eefbf012fb9754484f987b9fbf399/drizzle/0005_marvelous_master_chief.sql#L1-L4
- Journal entry: https://github.com/paul-bouzian/1code/blob/15ee55107f3eefbf012fb9754484f987b9fbf399/drizzle/meta/_journal.json#L40-L46

### Extra context
There’s also a `0005_add_subchat_stats.sql` file in the repo that adds those columns, but it isn’t referenced in drizzle/meta/_journal.json, so it won’t be picked up by the migrator. That can make it look like the columns should exist when they don’t.

### Fix
Remove the unsafe `DROP COLUMN` statements from `0005_marvelous_master_chief.sql` (keeping the index creation). 

### Testing
Reproduced locally on macOS (arm64): startup fails with `SQLITE_ERROR: no such column` before the change.
After the change: migrations complete and the app starts normally.