### PR TITLE
Fix: use `jsonc-parser` for robust VSCode theme detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "21st-desktop",
@@ -50,6 +51,7 @@
         "electron-updater": "^6.7.3",
         "gray-matter": "^4.0.3",
         "jotai": "^2.11.1",
+        "jsonc-parser": "^3.3.1",
         "lucide-react": "^0.468.0",
         "mermaid": "^11.12.2",
         "motion": "^11.15.0",
@@ -1480,6 +1482,8 @@
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "electron-updater": "^6.7.3",
     "gray-matter": "^4.0.3",
     "jotai": "^2.11.1",
+    "jsonc-parser": "^3.3.1",
     "lucide-react": "^0.468.0",
     "mermaid": "^11.12.2",
     "motion": "^11.15.0",


### PR DESCRIPTION
## Summary
- Replaced regex-based JSONC parsing with `jsonc-parser` (VS Code's official parser) for theme file loading
- Fixes issue where some valid theme files (e.g., Dracula) were silently failing to parse and not appearing in the appearance settings

## Problem
Themes installed in `~/.cursor/extensions` or `~/.vscode/extensions` were not showing up in the "From editors" section of the appearance settings, even though they had valid `package.json` and theme JSON files.

## Solution
The regex-based JSONC parser was fragile and silently failed on some valid theme files. Switched to `jsonc-parser`, which is the same parser VS Code uses internally, ensuring reliable parsing of all theme files.

## Test plan
- [x] Open Settings > Appearance
- [x] Verify themes from installed editor extensions appear in "From editors" dropdown
- [x] Confirm previously missing themes (e.g., Dracula) now appear