### PR TITLE
feat: add archive script support for worktrees

### DIFF
--- a/src/main/lib/trpc/routers/worktree-config.ts
+++ b/src/main/lib/trpc/routers/worktree-config.ts
@@ -13,6 +13,9 @@ const WorktreeConfigSchema = z.object({
   "setup-worktree-unix": z.union([z.array(z.string()), z.string()]).optional(),
   "setup-worktree-windows": z.union([z.array(z.string()), z.string()]).optional(),
   "setup-worktree": z.union([z.array(z.string()), z.string()]).optional(),
+  "archive-worktree-unix": z.union([z.array(z.string()), z.string()]).optional(),
+  "archive-worktree-windows": z.union([z.array(z.string()), z.string()]).optional(),
+  "archive-worktree": z.union([z.array(z.string()), z.string()]).optional(),
 })
 
 export const worktreeConfigRouter = router({


### PR DESCRIPTION
## Summary

Add the ability to configure commands that run when a workspace is archived, mirroring the existing setup script functionality.

- Add archive-worktree, archive-worktree-unix, archive-worktree-windows config keys
- Add `getArchiveCommands()` and `executeWorktreeArchive()` functions  
- Integrate archive script execution in chats.archive mutation
- Add "Archive Commands" section to project worktree settings UI

## How it works

The archive script runs whenever a workspace with a worktree is archived, **before** the worktree is deleted (if deletion is requested). This allows users to run cleanup tasks like:
- `git fetch --prune` - clean up remote tracking branches
- `git branch -d feature-branch` - delete local branches
- Custom cleanup scripts

## Configuration

Commands are stored in `.1code/worktree.json` alongside setup commands:

```json
{
  "setup-worktree": ["bun install"],
  "archive-worktree": ["git fetch --prune"]
}
```

## Test plan

- [x] Configure archive commands in Settings → Project → Worktree Scripts
- [x] Archive a workspace and verify commands run (check console logs)
- [x] Verify worktree deletion still works after archive script runs
- [ ] Test platform-specific overrides (unix/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)