### PR TITLE
feat: add model usage statistics tracking with heatmap and CSV export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "21st-desktop",

--- a/drizzle/0007_add_model_usage.sql
+++ b/drizzle/0007_add_model_usage.sql
@@ -1,0 +1,27 @@
+-- Model usage tracking table
+-- Records token usage for each Claude API call
+CREATE TABLE `model_usage` (
+	`id` text PRIMARY KEY NOT NULL,
+	`sub_chat_id` text NOT NULL REFERENCES `sub_chats`(`id`) ON DELETE CASCADE,
+	`chat_id` text NOT NULL REFERENCES `chats`(`id`) ON DELETE CASCADE,
+	`project_id` text NOT NULL REFERENCES `projects`(`id`) ON DELETE CASCADE,
+	`model` text NOT NULL,
+	`input_tokens` integer NOT NULL DEFAULT 0,
+	`output_tokens` integer NOT NULL DEFAULT 0,
+	`total_tokens` integer NOT NULL DEFAULT 0,
+	`cost_usd` text,
+	`session_id` text,
+	`message_uuid` text,
+	`mode` text,
+	`duration_ms` integer,
+	`created_at` integer
+);--> statement-breakpoint
+
+-- Indexes for query optimization
+CREATE INDEX `model_usage_created_at_idx` ON `model_usage` (`created_at`);--> statement-breakpoint
+CREATE INDEX `model_usage_model_idx` ON `model_usage` (`model`);--> statement-breakpoint
+CREATE INDEX `model_usage_project_id_idx` ON `model_usage` (`project_id`);--> statement-breakpoint
+CREATE INDEX `model_usage_chat_id_idx` ON `model_usage` (`chat_id`);--> statement-breakpoint
+CREATE INDEX `model_usage_sub_chat_id_idx` ON `model_usage` (`sub_chat_id`);--> statement-breakpoint
+-- Unique index for deduplication by message UUID
+CREATE UNIQUE INDEX `model_usage_message_uuid_idx` ON `model_usage` (`message_uuid`);

--- a/drizzle/0007_watery_winter_soldier.sql
+++ b/drizzle/0007_watery_winter_soldier.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `model_usage` (
+	`id` text PRIMARY KEY NOT NULL,
+	`sub_chat_id` text NOT NULL,
+	`chat_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`model` text NOT NULL,
+	`input_tokens` integer DEFAULT 0 NOT NULL,
+	`output_tokens` integer DEFAULT 0 NOT NULL,
+	`total_tokens` integer DEFAULT 0 NOT NULL,
+	`cost_usd` text,
+	`session_id` text,
+	`message_uuid` text,
+	`mode` text,
+	`duration_ms` integer,
+	`created_at` integer,
+	FOREIGN KEY (`sub_chat_id`) REFERENCES `sub_chats`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`chat_id`) REFERENCES `chats`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,578 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "66de5a0e-1d1c-41c8-8ca9-622482a8fcda",
+  "prevId": "b1c2d3e4-f5a6-7890-bcde-fa1234567890",
+  "tables": {
+    "anthropic_accounts": {
+      "name": "anthropic_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token": {
+          "name": "oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_user_id": {
+          "name": "desktop_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "anthropic_settings": {
+      "name": "anthropic_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'singleton'"
+        },
+        "active_account_id": {
+          "name": "active_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chats_worktree_path_idx": {
+          "name": "chats_worktree_path_idx",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claude_code_credentials": {
+      "name": "claude_code_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "oauth_token": {
+          "name": "oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_usage": {
+      "name": "model_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub_chat_id": {
+          "name": "sub_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_uuid": {
+          "name": "message_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_usage_sub_chat_id_sub_chats_id_fk": {
+          "name": "model_usage_sub_chat_id_sub_chats_id_fk",
+          "tableFrom": "model_usage",
+          "tableTo": "sub_chats",
+          "columnsFrom": [
+            "sub_chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_usage_chat_id_chats_id_fk": {
+          "name": "model_usage_chat_id_chats_id_fk",
+          "tableFrom": "model_usage",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_usage_project_id_projects_id_fk": {
+          "name": "model_usage_project_id_projects_id_fk",
+          "tableFrom": "model_usage",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_remote_url": {
+          "name": "git_remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_provider": {
+          "name": "git_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_owner": {
+          "name": "git_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_repo": {
+          "name": "git_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_path_unique": {
+          "name": "projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sub_chats": {
+      "name": "sub_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sub_chats_chat_id_chats_id_fk": {
+          "name": "sub_chats_chat_id_chats_id_fk",
+          "tableFrom": "sub_chats",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1769480000000,
       "tag": "0006_anthropic_multi_account",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1769541435416,
+      "tag": "0007_watery_winter_soldier",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/lib/claude/types.ts
+++ b/src/main/lib/claude/types.ts
@@ -65,6 +65,14 @@ export type MCPServer = {
   error?: string
 }
 
+export type ModelUsageEntry = {
+  inputTokens: number
+  outputTokens: number
+  cacheReadInputTokens: number
+  cacheCreationInputTokens: number
+  costUSD: number
+}
+
 export type MessageMetadata = {
   sessionId?: string
   sdkMessageUuid?: string // SDK's message UUID for resumeSessionAt (rollback support)
@@ -75,4 +83,6 @@ export type MessageMetadata = {
   durationMs?: number
   resultSubtype?: string
   finalTextId?: string
+  // Per-model usage breakdown from SDK (model name -> usage)
+  modelUsage?: Record<string, ModelUsageEntry>
 }

--- a/src/main/lib/db/schema/index.ts
+++ b/src/main/lib/db/schema/index.ts
@@ -126,6 +126,57 @@ export const anthropicSettings = sqliteTable("anthropic_settings", {
   ),
 })
 
+// ============ MODEL USAGE ============
+// Records token usage for each Claude API call
+export const modelUsage = sqliteTable("model_usage", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => createId()),
+  // Relationships
+  subChatId: text("sub_chat_id")
+    .notNull()
+    .references(() => subChats.id, { onDelete: "cascade" }),
+  chatId: text("chat_id")
+    .notNull()
+    .references(() => chats.id, { onDelete: "cascade" }),
+  projectId: text("project_id")
+    .notNull()
+    .references(() => projects.id, { onDelete: "cascade" }),
+  // Model info
+  model: text("model").notNull(),
+  // Token usage
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  totalTokens: integer("total_tokens").notNull().default(0),
+  // Cost in USD (stored as text for decimal precision)
+  costUsd: text("cost_usd"),
+  // Session info (for deduplication)
+  sessionId: text("session_id"),
+  messageUuid: text("message_uuid"), // SDK message UUID for deduplication
+  // Request metadata
+  mode: text("mode"), // "plan" | "agent"
+  durationMs: integer("duration_ms"),
+  // Timestamp
+  createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
+    () => new Date(),
+  ),
+})
+
+export const modelUsageRelations = relations(modelUsage, ({ one }) => ({
+  subChat: one(subChats, {
+    fields: [modelUsage.subChatId],
+    references: [subChats.id],
+  }),
+  chat: one(chats, {
+    fields: [modelUsage.chatId],
+    references: [chats.id],
+  }),
+  project: one(projects, {
+    fields: [modelUsage.projectId],
+    references: [projects.id],
+  }),
+}))
+
 // ============ TYPE EXPORTS ============
 export type Project = typeof projects.$inferSelect
 export type NewProject = typeof projects.$inferInsert
@@ -138,3 +189,5 @@ export type NewClaudeCodeCredential = typeof claudeCodeCredentials.$inferInsert
 export type AnthropicAccount = typeof anthropicAccounts.$inferSelect
 export type NewAnthropicAccount = typeof anthropicAccounts.$inferInsert
 export type AnthropicSettings = typeof anthropicSettings.$inferSelect
+export type ModelUsage = typeof modelUsage.$inferSelect
+export type NewModelUsage = typeof modelUsage.$inferInsert

--- a/src/main/lib/trpc/routers/index.ts
+++ b/src/main/lib/trpc/routers/index.ts
@@ -16,6 +16,7 @@ import { worktreeConfigRouter } from "./worktree-config"
 import { sandboxImportRouter } from "./sandbox-import"
 import { commandsRouter } from "./commands"
 import { voiceRouter } from "./voice"
+import { usageRouter } from "./usage"
 import { createGitRouter } from "../../git"
 import { BrowserWindow } from "electron"
 
@@ -42,6 +43,7 @@ export function createAppRouter(getWindow: () => BrowserWindow | null) {
     sandboxImport: sandboxImportRouter,
     commands: commandsRouter,
     voice: voiceRouter,
+    usage: usageRouter,
     // Git operations - named "changes" to match Superset API
     changes: createGitRouter(),
   })

--- a/src/main/lib/trpc/routers/usage.ts
+++ b/src/main/lib/trpc/routers/usage.ts
@@ -1,0 +1,381 @@
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm"
+import { z } from "zod"
+import { getDatabase, modelUsage, projects, chats, subChats } from "../../db"
+import { publicProcedure, router } from "../index"
+
+// Date range schema for filtering
+const dateRangeSchema = z.object({
+  startDate: z.string().optional(), // ISO date string, e.g., "2024-01-01"
+  endDate: z.string().optional(),
+})
+
+export const usageRouter = router({
+  /**
+   * Record a single usage entry (called internally by claude.ts)
+   */
+  record: publicProcedure
+    .input(
+      z.object({
+        subChatId: z.string(),
+        chatId: z.string(),
+        projectId: z.string(),
+        model: z.string(),
+        inputTokens: z.number(),
+        outputTokens: z.number(),
+        totalTokens: z.number(),
+        costUsd: z.number().optional(),
+        sessionId: z.string().optional(),
+        messageUuid: z.string().optional(),
+        mode: z.enum(["plan", "agent"]).optional(),
+        durationMs: z.number().optional(),
+      }),
+    )
+    .mutation(({ input }) => {
+      const db = getDatabase()
+
+      // Check for duplicate by messageUuid
+      if (input.messageUuid) {
+        const existing = db
+          .select()
+          .from(modelUsage)
+          .where(eq(modelUsage.messageUuid, input.messageUuid))
+          .get()
+
+        if (existing) {
+          console.log(`[Usage] Skipping duplicate record: ${input.messageUuid}`)
+          return existing
+        }
+      }
+
+      return db
+        .insert(modelUsage)
+        .values({
+          subChatId: input.subChatId,
+          chatId: input.chatId,
+          projectId: input.projectId,
+          model: input.model,
+          inputTokens: input.inputTokens,
+          outputTokens: input.outputTokens,
+          totalTokens: input.totalTokens,
+          costUsd: input.costUsd?.toFixed(6),
+          sessionId: input.sessionId,
+          messageUuid: input.messageUuid,
+          mode: input.mode,
+          durationMs: input.durationMs,
+        })
+        .returning()
+        .get()
+    }),
+
+  /**
+   * Get usage summary (for settings page quick view)
+   */
+  getSummary: publicProcedure.query(() => {
+    const db = getDatabase()
+    const now = new Date()
+
+    // Today start
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    // Week start (Monday)
+    const weekStart = new Date(todayStart)
+    weekStart.setDate(weekStart.getDate() - ((weekStart.getDay() + 6) % 7))
+    // Month start
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
+
+    // Today usage
+    const todayUsage = db
+      .select({
+        totalInputTokens: sql<number>`coalesce(sum(${modelUsage.inputTokens}), 0)`,
+        totalOutputTokens: sql<number>`coalesce(sum(${modelUsage.outputTokens}), 0)`,
+        totalTokens: sql<number>`coalesce(sum(${modelUsage.totalTokens}), 0)`,
+        totalCostUsd: sql<number>`coalesce(sum(cast(${modelUsage.costUsd} as real)), 0)`,
+        count: sql<number>`count(*)`,
+      })
+      .from(modelUsage)
+      .where(gte(modelUsage.createdAt, todayStart))
+      .get()
+
+    // Week usage
+    const weekUsage = db
+      .select({
+        totalInputTokens: sql<number>`coalesce(sum(${modelUsage.inputTokens}), 0)`,
+        totalOutputTokens: sql<number>`coalesce(sum(${modelUsage.outputTokens}), 0)`,
+        totalTokens: sql<number>`coalesce(sum(${modelUsage.totalTokens}), 0)`,
+        totalCostUsd: sql<number>`coalesce(sum(cast(${modelUsage.costUsd} as real)), 0)`,
+        count: sql<number>`count(*)`,
+      })
+      .from(modelUsage)
+      .where(gte(modelUsage.createdAt, weekStart))
+      .get()
+
+    // Month usage
+    const monthUsage = db
+      .select({
+        totalInputTokens: sql<number>`coalesce(sum(${modelUsage.inputTokens}), 0)`,
+        totalOutputTokens: sql<number>`coalesce(sum(${modelUsage.outputTokens}), 0)`,
+        totalTokens: sql<number>`coalesce(sum(${modelUsage.totalTokens}), 0)`,
+        totalCostUsd: sql<number>`coalesce(sum(cast(${modelUsage.costUsd} as real)), 0)`,
+        count: sql<number>`count(*)`,
+      })
+      .from(modelUsage)
+      .where(gte(modelUsage.createdAt, monthStart))
+      .get()
+
+    // Total usage
+    const totalUsage = db
+      .select({
+        totalInputTokens: sql<number>`coalesce(sum(${modelUsage.inputTokens}), 0)`,
+        totalOutputTokens: sql<number>`coalesce(sum(${modelUsage.outputTokens}), 0)`,
+        totalTokens: sql<number>`coalesce(sum(${modelUsage.totalTokens}), 0)`,
+        totalCostUsd: sql<number>`coalesce(sum(cast(${modelUsage.costUsd} as real)), 0)`,
+        count: sql<number>`count(*)`,
+      })
+      .from(modelUsage)
+      .get()
+
+    return {
+      today: todayUsage,
+      week: weekUsage,
+      month: monthUsage,
+      total: totalUsage,
+    }
+  }),
+
+  /**
+   * Get daily activity for heatmap (last 365 days)
+   * Returns array of { date, count, totalTokens } for contribution graph
+   */
+  getDailyActivity: publicProcedure.query(() => {
+    const db = getDatabase()
+    const now = new Date()
+    const yearAgo = new Date(now)
+    yearAgo.setFullYear(yearAgo.getFullYear() - 1)
+
+    return db
+      .select({
+        date: sql<string>`date(${modelUsage.createdAt}, 'unixepoch')`.as("date"),
+        count: sql<number>`count(*)`,
+        totalTokens: sql<number>`sum(${modelUsage.totalTokens})`,
+      })
+      .from(modelUsage)
+      .where(gte(modelUsage.createdAt, yearAgo))
+      .groupBy(sql`date(${modelUsage.createdAt}, 'unixepoch')`)
+      .orderBy(sql`date`)
+      .all()
+  }),
+
+  /**
+   * Get usage grouped by date
+   */
+  getByDate: publicProcedure.input(dateRangeSchema).query(({ input }) => {
+    const db = getDatabase()
+
+    const conditions = []
+    if (input.startDate) {
+      conditions.push(gte(modelUsage.createdAt, new Date(input.startDate)))
+    }
+    if (input.endDate) {
+      const endDate = new Date(input.endDate)
+      endDate.setDate(endDate.getDate() + 1)
+      conditions.push(lte(modelUsage.createdAt, endDate))
+    }
+
+    const baseQuery = db
+      .select({
+        date: sql<string>`date(${modelUsage.createdAt}, 'unixepoch')`.as(
+          "date",
+        ),
+        totalInputTokens: sql<number>`sum(${modelUsage.inputTokens})`,
+        totalOutputTokens: sql<number>`sum(${modelUsage.outputTokens})`,
+        totalTokens: sql<number>`sum(${modelUsage.totalTokens})`,
+        totalCostUsd: sql<number>`sum(cast(${modelUsage.costUsd} as real))`,
+        count: sql<number>`count(*)`,
+      })
+      .from(modelUsage)
+
+    const query =
+      conditions.length > 0
+        ? baseQuery.where(and(...conditions))
+        : baseQuery
+
+    return query
+      .groupBy(sql`date(${modelUsage.createdAt}, 'unixepoch')`)
+      .orderBy(desc(sql`date`))
+      .all()
+  }),
+
+  /**
+   * Get usage grouped by model
+   */
+  getByModel: publicProcedure.input(dateRangeSchema).query(({ input }) => {
+    const db = getDatabase()
+
+    const conditions = []
+    if (input.startDate) {
+      conditions.push(gte(modelUsage.createdAt, new Date(input.startDate)))
+    }
+    if (input.endDate) {
+      const endDate = new Date(input.endDate)
+      endDate.setDate(endDate.getDate() + 1)
+      conditions.push(lte(modelUsage.createdAt, endDate))
+    }
+
+    const baseQuery = db
+      .select({
+        model: modelUsage.model,
+        totalInputTokens: sql<number>`sum(${modelUsage.inputTokens})`,
+        totalOutputTokens: sql<number>`sum(${modelUsage.outputTokens})`,
+        totalTokens: sql<number>`sum(${modelUsage.totalTokens})`,
+        totalCostUsd: sql<number>`sum(cast(${modelUsage.costUsd} as real))`,
+        count: sql<number>`count(*)`,
+      })
+      .from(modelUsage)
+
+    const query =
+      conditions.length > 0
+        ? baseQuery.where(and(...conditions))
+        : baseQuery
+
+    return query
+      .groupBy(modelUsage.model)
+      .orderBy(desc(sql`sum(${modelUsage.totalTokens})`))
+      .all()
+  }),
+
+  /**
+   * Get usage grouped by project
+   */
+  getByProject: publicProcedure.input(dateRangeSchema).query(({ input }) => {
+    const db = getDatabase()
+
+    const conditions = []
+    if (input.startDate) {
+      conditions.push(gte(modelUsage.createdAt, new Date(input.startDate)))
+    }
+    if (input.endDate) {
+      const endDate = new Date(input.endDate)
+      endDate.setDate(endDate.getDate() + 1)
+      conditions.push(lte(modelUsage.createdAt, endDate))
+    }
+
+    const baseQuery = db
+      .select({
+        projectId: modelUsage.projectId,
+        projectName: projects.name,
+        totalInputTokens: sql<number>`sum(${modelUsage.inputTokens})`,
+        totalOutputTokens: sql<number>`sum(${modelUsage.outputTokens})`,
+        totalTokens: sql<number>`sum(${modelUsage.totalTokens})`,
+        totalCostUsd: sql<number>`sum(cast(${modelUsage.costUsd} as real))`,
+        count: sql<number>`count(*)`,
+      })
+      .from(modelUsage)
+      .leftJoin(projects, eq(modelUsage.projectId, projects.id))
+
+    const query =
+      conditions.length > 0
+        ? baseQuery.where(and(...conditions))
+        : baseQuery
+
+    return query
+      .groupBy(modelUsage.projectId)
+      .orderBy(desc(sql`sum(${modelUsage.totalTokens})`))
+      .all()
+  }),
+
+  /**
+   * Get usage grouped by subchat
+   */
+  getBySubChat: publicProcedure
+    .input(
+      z.object({
+        projectId: z.string().optional(),
+        chatId: z.string().optional(),
+        ...dateRangeSchema.shape,
+      }),
+    )
+    .query(({ input }) => {
+      const db = getDatabase()
+
+      const conditions = []
+      if (input.projectId) {
+        conditions.push(eq(modelUsage.projectId, input.projectId))
+      }
+      if (input.chatId) {
+        conditions.push(eq(modelUsage.chatId, input.chatId))
+      }
+      if (input.startDate) {
+        conditions.push(gte(modelUsage.createdAt, new Date(input.startDate)))
+      }
+      if (input.endDate) {
+        const endDate = new Date(input.endDate)
+        endDate.setDate(endDate.getDate() + 1)
+        conditions.push(lte(modelUsage.createdAt, endDate))
+      }
+
+      const baseQuery = db
+        .select({
+          subChatId: modelUsage.subChatId,
+          subChatName: subChats.name,
+          chatId: modelUsage.chatId,
+          chatName: chats.name,
+          projectName: projects.name,
+          totalInputTokens: sql<number>`sum(${modelUsage.inputTokens})`,
+          totalOutputTokens: sql<number>`sum(${modelUsage.outputTokens})`,
+          totalTokens: sql<number>`sum(${modelUsage.totalTokens})`,
+          totalCostUsd: sql<number>`sum(cast(${modelUsage.costUsd} as real))`,
+          count: sql<number>`count(*)`,
+        })
+        .from(modelUsage)
+        .leftJoin(subChats, eq(modelUsage.subChatId, subChats.id))
+        .leftJoin(chats, eq(modelUsage.chatId, chats.id))
+        .leftJoin(projects, eq(modelUsage.projectId, projects.id))
+
+      const query =
+        conditions.length > 0
+          ? baseQuery.where(and(...conditions))
+          : baseQuery
+
+      return query
+        .groupBy(modelUsage.subChatId)
+        .orderBy(desc(sql`sum(${modelUsage.totalTokens})`))
+        .all()
+    }),
+
+  /**
+   * Get recent usage records (paginated)
+   */
+  getRecent: publicProcedure
+    .input(
+      z.object({
+        limit: z.number().default(50),
+        offset: z.number().default(0),
+      }),
+    )
+    .query(({ input }) => {
+      const db = getDatabase()
+
+      return db
+        .select({
+          id: modelUsage.id,
+          model: modelUsage.model,
+          inputTokens: modelUsage.inputTokens,
+          outputTokens: modelUsage.outputTokens,
+          totalTokens: modelUsage.totalTokens,
+          costUsd: modelUsage.costUsd,
+          mode: modelUsage.mode,
+          durationMs: modelUsage.durationMs,
+          createdAt: modelUsage.createdAt,
+          subChatName: subChats.name,
+          chatName: chats.name,
+          projectName: projects.name,
+        })
+        .from(modelUsage)
+        .leftJoin(subChats, eq(modelUsage.subChatId, subChats.id))
+        .leftJoin(chats, eq(modelUsage.chatId, chats.id))
+        .leftJoin(projects, eq(modelUsage.projectId, projects.id))
+        .orderBy(desc(modelUsage.createdAt))
+        .limit(input.limit)
+        .offset(input.offset)
+        .all()
+    }),
+})

--- a/src/renderer/components/dialogs/settings-tabs/usage-details-dialog.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/usage-details-dialog.tsx
@@ -1,0 +1,473 @@
+import { Calendar, Database, Download, FolderOpen, MessageSquare, X } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+import { trpc } from "../../../lib/trpc"
+import { Button } from "../../ui/button"
+import { Dialog, DialogContent } from "../../ui/dialog"
+import { cn } from "../../../lib/utils"
+
+interface UsageDetailsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+type ViewMode = "date" | "model" | "project" | "subchat"
+
+// Helper to format token count
+function formatTokenCount(tokens: number): string {
+  if (!tokens) return "0"
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(2)}M`
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`
+  return String(tokens)
+}
+
+// Helper to format cost
+function formatCost(cost: number): string {
+  if (!cost) return "$0.00"
+  return `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}`
+}
+
+// Get default start date (30 days ago)
+function getDefaultStartDate(): string {
+  const date = new Date()
+  date.setDate(date.getDate() - 30)
+  return date.toISOString().split("T")[0]!
+}
+
+// Tab button component
+function TabButton({
+  active,
+  onClick,
+  icon: Icon,
+  label,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
+        active
+          ? "bg-primary/10 text-primary"
+          : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {label}
+    </button>
+  )
+}
+
+// Usage table component
+interface UsageTableProps {
+  data: any[]
+  columns: Array<{
+    key: string
+    label: string
+    format?: (value: any) => string
+    fallback?: string
+  }>
+}
+
+function UsageTable({ data, columns }: UsageTableProps) {
+  if (!data || data.length === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        No usage data found for the selected period.
+      </div>
+    )
+  }
+
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/50">
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className="px-4 py-2 text-left font-medium text-muted-foreground"
+              >
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, i) => (
+            <tr
+              key={i}
+              className="border-t border-border hover:bg-muted/30 transition-colors"
+            >
+              {columns.map((col) => (
+                <td key={col.key} className="px-4 py-2">
+                  {col.format
+                    ? col.format(row[col.key])
+                    : row[col.key] || col.fallback || "-"}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// CSV export helper
+function exportToCsv(data: any[], columns: Array<{ key: string; label: string }>, filename: string) {
+  if (!data || data.length === 0) {
+    toast.error("No data to export")
+    return
+  }
+
+  // Build CSV header
+  const header = columns.map((col) => col.label).join(",")
+
+  // Build CSV rows
+  const rows = data.map((row) =>
+    columns
+      .map((col) => {
+        const value = row[col.key]
+        // Handle null/undefined
+        if (value === null || value === undefined) return ""
+        // Escape quotes and wrap in quotes if contains comma
+        const strValue = String(value)
+        if (strValue.includes(",") || strValue.includes('"') || strValue.includes("\n")) {
+          return `"${strValue.replace(/"/g, '""')}"`
+        }
+        return strValue
+      })
+      .join(",")
+  )
+
+  const csvContent = [header, ...rows].join("\n")
+
+  // Create and trigger download
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+
+  toast.success(`Exported ${data.length} rows to ${filename}`)
+}
+
+export function UsageDetailsDialog({
+  open,
+  onOpenChange,
+}: UsageDetailsDialogProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>("date")
+  const [dateRange, setDateRange] = useState({
+    startDate: getDefaultStartDate(),
+    endDate: new Date().toISOString().split("T")[0]!,
+  })
+
+  // Data queries
+  const { data: byDate, isLoading: byDateLoading } =
+    trpc.usage.getByDate.useQuery(dateRange, {
+      enabled: open && viewMode === "date",
+    })
+  const { data: byModel, isLoading: byModelLoading } =
+    trpc.usage.getByModel.useQuery(dateRange, {
+      enabled: open && viewMode === "model",
+    })
+  const { data: byProject, isLoading: byProjectLoading } =
+    trpc.usage.getByProject.useQuery(dateRange, {
+      enabled: open && viewMode === "project",
+    })
+  const { data: bySubChat, isLoading: bySubChatLoading } =
+    trpc.usage.getBySubChat.useQuery(dateRange, {
+      enabled: open && viewMode === "subchat",
+    })
+
+  const isLoading =
+    (viewMode === "date" && byDateLoading) ||
+    (viewMode === "model" && byModelLoading) ||
+    (viewMode === "project" && byProjectLoading) ||
+    (viewMode === "subchat" && bySubChatLoading)
+
+  // Handle CSV export
+  const handleExport = () => {
+    const timestamp = new Date().toISOString().split("T")[0]
+
+    switch (viewMode) {
+      case "date":
+        exportToCsv(
+          byDate || [],
+          [
+            { key: "date", label: "Date" },
+            { key: "totalInputTokens", label: "Input Tokens" },
+            { key: "totalOutputTokens", label: "Output Tokens" },
+            { key: "totalTokens", label: "Total Tokens" },
+            { key: "totalCostUsd", label: "Cost (USD)" },
+            { key: "count", label: "Requests" },
+          ],
+          `usage-by-date-${timestamp}.csv`
+        )
+        break
+      case "model":
+        exportToCsv(
+          byModel || [],
+          [
+            { key: "model", label: "Model" },
+            { key: "totalInputTokens", label: "Input Tokens" },
+            { key: "totalOutputTokens", label: "Output Tokens" },
+            { key: "totalTokens", label: "Total Tokens" },
+            { key: "totalCostUsd", label: "Cost (USD)" },
+            { key: "count", label: "Requests" },
+          ],
+          `usage-by-model-${timestamp}.csv`
+        )
+        break
+      case "project":
+        exportToCsv(
+          byProject || [],
+          [
+            { key: "projectName", label: "Project" },
+            { key: "totalInputTokens", label: "Input Tokens" },
+            { key: "totalOutputTokens", label: "Output Tokens" },
+            { key: "totalTokens", label: "Total Tokens" },
+            { key: "totalCostUsd", label: "Cost (USD)" },
+            { key: "count", label: "Requests" },
+          ],
+          `usage-by-project-${timestamp}.csv`
+        )
+        break
+      case "subchat":
+        exportToCsv(
+          bySubChat || [],
+          [
+            { key: "subChatName", label: "Agent" },
+            { key: "chatName", label: "Workspace" },
+            { key: "projectName", label: "Project" },
+            { key: "totalInputTokens", label: "Input Tokens" },
+            { key: "totalOutputTokens", label: "Output Tokens" },
+            { key: "totalTokens", label: "Total Tokens" },
+            { key: "totalCostUsd", label: "Cost (USD)" },
+            { key: "count", label: "Requests" },
+          ],
+          `usage-by-agent-${timestamp}.csv`
+        )
+        break
+    }
+  }
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center py-12 text-muted-foreground">
+          Loading...
+        </div>
+      )
+    }
+
+    switch (viewMode) {
+      case "date":
+        return (
+          <UsageTable
+            data={byDate || []}
+            columns={[
+              { key: "date", label: "Date" },
+              {
+                key: "totalInputTokens",
+                label: "Input",
+                format: formatTokenCount,
+              },
+              {
+                key: "totalOutputTokens",
+                label: "Output",
+                format: formatTokenCount,
+              },
+              {
+                key: "totalTokens",
+                label: "Total",
+                format: formatTokenCount,
+              },
+              { key: "totalCostUsd", label: "Cost", format: formatCost },
+              { key: "count", label: "Requests" },
+            ]}
+          />
+        )
+      case "model":
+        return (
+          <UsageTable
+            data={byModel || []}
+            columns={[
+              { key: "model", label: "Model" },
+              {
+                key: "totalInputTokens",
+                label: "Input",
+                format: formatTokenCount,
+              },
+              {
+                key: "totalOutputTokens",
+                label: "Output",
+                format: formatTokenCount,
+              },
+              {
+                key: "totalTokens",
+                label: "Total",
+                format: formatTokenCount,
+              },
+              { key: "totalCostUsd", label: "Cost", format: formatCost },
+              { key: "count", label: "Requests" },
+            ]}
+          />
+        )
+      case "project":
+        return (
+          <UsageTable
+            data={byProject || []}
+            columns={[
+              { key: "projectName", label: "Project", fallback: "Unknown" },
+              {
+                key: "totalInputTokens",
+                label: "Input",
+                format: formatTokenCount,
+              },
+              {
+                key: "totalOutputTokens",
+                label: "Output",
+                format: formatTokenCount,
+              },
+              {
+                key: "totalTokens",
+                label: "Total",
+                format: formatTokenCount,
+              },
+              { key: "totalCostUsd", label: "Cost", format: formatCost },
+              { key: "count", label: "Requests" },
+            ]}
+          />
+        )
+      case "subchat":
+        return (
+          <UsageTable
+            data={bySubChat || []}
+            columns={[
+              { key: "subChatName", label: "Agent", fallback: "Unnamed" },
+              { key: "chatName", label: "Workspace", fallback: "Unnamed" },
+              { key: "projectName", label: "Project", fallback: "Unknown" },
+              {
+                key: "totalTokens",
+                label: "Tokens",
+                format: formatTokenCount,
+              },
+              { key: "totalCostUsd", label: "Cost", format: formatCost },
+            ]}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-4xl w-[90vw] h-[80vh] p-0 gap-0 flex flex-col overflow-hidden"
+        showCloseButton={false}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b shrink-0">
+          <h2 className="text-lg font-semibold">Usage Details</h2>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => onOpenChange(false)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Content */}
+        <div className="p-4 overflow-y-auto flex-1">
+          {/* View Mode Tabs */}
+          <div className="flex flex-wrap gap-2 mb-4">
+            <TabButton
+              active={viewMode === "date"}
+              onClick={() => setViewMode("date")}
+              icon={Calendar}
+              label="By Date"
+            />
+            <TabButton
+              active={viewMode === "model"}
+              onClick={() => setViewMode("model")}
+              icon={Database}
+              label="By Model"
+            />
+            <TabButton
+              active={viewMode === "project"}
+              onClick={() => setViewMode("project")}
+              icon={FolderOpen}
+              label="By Project"
+            />
+            <TabButton
+              active={viewMode === "subchat"}
+              onClick={() => setViewMode("subchat")}
+              icon={MessageSquare}
+              label="By Agent"
+            />
+          </div>
+
+          {/* Date Range Picker and Export */}
+          <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
+            <div className="flex flex-wrap items-center gap-4">
+              <div className="flex items-center gap-2">
+                <label className="text-sm text-muted-foreground">From:</label>
+                <input
+                  type="date"
+                  value={dateRange.startDate}
+                  onChange={(e) =>
+                    setDateRange((prev) => ({
+                      ...prev,
+                      startDate: e.target.value,
+                    }))
+                  }
+                  className="px-2 py-1 text-sm border rounded bg-background"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <label className="text-sm text-muted-foreground">To:</label>
+                <input
+                  type="date"
+                  value={dateRange.endDate}
+                  onChange={(e) =>
+                    setDateRange((prev) => ({
+                      ...prev,
+                      endDate: e.target.value,
+                    }))
+                  }
+                  className="px-2 py-1 text-sm border rounded bg-background"
+                />
+              </div>
+            </div>
+
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleExport}
+              disabled={isLoading}
+            >
+              <Download className="h-3 w-3 mr-1" />
+              Export CSV
+            </Button>
+          </div>
+
+          {/* Table */}
+          {renderContent()}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
- Add GitHub-style contribution heatmap for visualizing daily usage
- Track per-model token usage (input, output, cache) and costs
- Support CSV export for usage data
- Extract modelUsage from SDK result message for accurate per-model attribution
- Query projectId from chat record for proper database relations

<img width="1228" height="950" alt="image" src="https://github.com/user-attachments/assets/0aa751dc-9cdd-44b5-b6cb-afbb12824f42" />
<img width="1259" height="996" alt="image" src="https://github.com/user-attachments/assets/732b8337-45cc-4391-aca7-759dfe1eed53" />
