### PR TITLE
fix: pass project path to skills and agents queries

### DIFF
--- a/src/renderer/components/dialogs/settings-tabs/agents-custom-agents-tab.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/agents-custom-agents-tab.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react"
+import { useAtomValue } from "jotai"
 import { ChevronRight } from "lucide-react"
 import { motion, AnimatePresence } from "motion/react"
+import { selectedProjectAtom } from "../../../features/agents/atoms"
 import { trpc } from "../../../lib/trpc"
 import { cn } from "../../../lib/utils"
 import { AgentIcon } from "../../ui/icons"
@@ -36,8 +38,11 @@ interface FileAgent {
 export function AgentsCustomAgentsTab() {
   const isNarrowScreen = useIsNarrowScreen()
   const [expandedAgentName, setExpandedAgentName] = useState<string | null>(null)
+  const selectedProject = useAtomValue(selectedProjectAtom)
 
-  const { data: agents = [], isLoading } = trpc.agents.list.useQuery(undefined)
+  const { data: agents = [], isLoading } = trpc.agents.list.useQuery(
+    selectedProject?.path ? { cwd: selectedProject.path } : undefined,
+  )
 
   const openInFinderMutation = trpc.external.openInFinder.useMutation()
 

--- a/src/renderer/components/dialogs/settings-tabs/agents-skills-tab.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/agents-skills-tab.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react"
+import { useAtomValue } from "jotai"
 import { ChevronRight } from "lucide-react"
 import { motion, AnimatePresence } from "motion/react"
+import { selectedProjectAtom } from "../../../features/agents/atoms"
 import { trpc } from "../../../lib/trpc"
 import { cn } from "../../../lib/utils"
 import { SkillIcon } from "../../ui/icons"
@@ -25,8 +27,11 @@ function useIsNarrowScreen(): boolean {
 export function AgentsSkillsTab() {
   const isNarrowScreen = useIsNarrowScreen()
   const [expandedSkillName, setExpandedSkillName] = useState<string | null>(null)
+  const selectedProject = useAtomValue(selectedProjectAtom)
 
-  const { data: skills = [], isLoading } = trpc.skills.list.useQuery(undefined)
+  const { data: skills = [], isLoading } = trpc.skills.list.useQuery(
+    selectedProject?.path ? { cwd: selectedProject.path } : undefined,
+  )
   const openInFinderMutation = trpc.external.openInFinder.useMutation()
 
   const userSkills = skills.filter((s) => s.source === "user")

--- a/src/renderer/features/agents/mentions/agents-file-mention.tsx
+++ b/src/renderer/features/agents/mentions/agents-file-mention.tsx
@@ -695,16 +695,22 @@ export const AgentsFileMention = memo(function AgentsFileMention({
   const sessionInfo = useAtomValue(sessionInfoAtom)
 
   // Fetch skills from filesystem (cached for 5 minutes)
-  const { data: skills = [], isFetching: isFetchingSkills } = trpc.skills.listEnabled.useQuery(undefined, {
-    enabled: isOpen,
-    staleTime: 5 * 60 * 1000, // 5 minutes - skills don't change frequently
-  })
+  const { data: skills = [], isFetching: isFetchingSkills } = trpc.skills.listEnabled.useQuery(
+    projectPath ? { cwd: projectPath } : undefined,
+    {
+      enabled: isOpen,
+      staleTime: 5 * 60 * 1000, // 5 minutes - skills don't change frequently
+    },
+  )
 
   // Fetch custom agents from filesystem (cached for 5 minutes)
-  const { data: customAgents = [], isFetching: isFetchingAgents } = trpc.agents.listEnabled.useQuery(undefined, {
-    enabled: isOpen,
-    staleTime: 5 * 60 * 1000, // 5 minutes - agents don't change frequently
-  })
+  const { data: customAgents = [], isFetching: isFetchingAgents } = trpc.agents.listEnabled.useQuery(
+    projectPath ? { cwd: projectPath } : undefined,
+    {
+      enabled: isOpen,
+      staleTime: 5 * 60 * 1000, // 5 minutes - agents don't change frequently
+    },
+  )
 
   // Debounce search text (300ms to match canvas implementation)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Skills and agents from project-level `.claude/` folders were not showing up in the settings tab or @ mention dropdown
- The backend tRPC routers already support scanning `<project>/.claude/skills/` and `<project>/.claude/agents/` via a `cwd` parameter, but two frontend callers were passing `undefined` instead of the project path
- Pass `selectedProject.path` in the skills settings tab and `projectPath` in the file mention dropdown to both `skills.listEnabled` and `agents.listEnabled` queries

## Test plan
- [ ] Open a project that has a `.claude/skills/` or `.claude/agents/` directory
- [ ] Open Settings > Skills tab — verify project-level skills appear alongside user-level ones
- [ ] Type `@` in the chat input — verify project-level skills and agents appear in the mention dropdown