### PR TITLE
perf: Optimize message sync loop and add LRU cache eviction

### DIFF
--- a/src/renderer/features/agents/stores/message-store.ts
+++ b/src/renderer/features/agents/stores/message-store.ts
@@ -2,6 +2,7 @@
 
 import { atom } from "jotai"
 import { atomFamily } from "jotai/utils"
+import { agentChatStore } from "./agent-chat-store"
 
 // Types
 export interface MessagePart {
@@ -85,6 +86,9 @@ function touchSubChat(subChatId: string) {
     const oldestSubChatId = subChatLRU.keys().next().value
     if (oldestSubChatId) {
       subChatLRU.delete(oldestSubChatId)
+      // CRITICAL: Abort any active stream before clearing caches
+      // This prevents background streams from continuing to consume resources
+      agentChatStore.abort(oldestSubChatId)
       clearSubChatCaches(oldestSubChatId)
     }
   }


### PR DESCRIPTION
## Summary

This PR addresses critical performance issues for long chat sessions:

### Performance Optimizations
- **O(1) sync during streaming** - During streaming, only the last message changes. Now only checks the last message instead of looping through all messages. Full sync only happens when IDs change or on first sync.
- **LRU cache eviction** - Tracks recently used subchats (max 10 cached) and automatically evicts oldest subchat caches when threshold exceeded, preventing unbounded memory growth.
- **Better cache cleanup** - Clears textPartCache and messageStructureCache entries when messages are removed.
- **Deep clone nested objects** - Fixed shallow cloning that omitted `output`, `result`, and `error` fields in message sync, ensuring Jotai detects all changes.
- **Eliminate duplicate token calculation** - Replaced O(n) useMemo in active-chat.tsx with centralized messageTokenDataAtom that uses caching for O(1) lookups during streaming.

### Stream Lifecycle Fixes
- **Abort streams on cache eviction** - When a sub-chat is evicted from LRU cache, its active stream is now aborted first, preventing background streams from consuming resources.
- **Proper cleanup on chat deletion** - `agentChatStore.delete()` now calls `abort()` first to ensure streams are stopped before removing references, preventing orphaned tRPC subscriptions.

## Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| Streaming sync | O(n) | O(1) |
| Token calculation | O(n) per render | O(1) cached |
| Memory (subchats) | Unbounded | Max 10 cached |
| Long sessions | Memory leak | Bounded |
| Background streams | Continue after eviction | Properly aborted |

## Test Plan

- [ ] Open a long chat session (100+ messages)
- [ ] Verify streaming is responsive (no lag during AI responses)
- [ ] Switch between multiple chats and verify memory doesn't grow unbounded
- [ ] Create new chats within a worktree and verify no lag
- [ ] Verify token counts display correctly after streaming completes
- [ ] Open 10+ sub-chats, verify oldest ones are evicted and streams stopped