### PR TITLE
fix(notifications): fix macOS desktop notifications

### DIFF
--- a/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
@@ -7,6 +7,7 @@ import {
   defaultAgentModeAtom,
   desktopNotificationsEnabledAtom,
   extendedThinkingEnabledAtom,
+  notifyWhenFocusedAtom,
   soundNotificationsEnabledAtom,
   preferredEditorAtom,
   type AgentMode,
@@ -146,6 +147,7 @@ export function AgentsPreferencesTab() {
   )
   const [soundEnabled, setSoundEnabled] = useAtom(soundNotificationsEnabledAtom)
   const [desktopNotificationsEnabled, setDesktopNotificationsEnabled] = useAtom(desktopNotificationsEnabledAtom)
+  const [notifyWhenFocused, setNotifyWhenFocused] = useAtom(notifyWhenFocusedAtom)
   const [analyticsOptOut, setAnalyticsOptOut] = useAtom(analyticsOptOutAtom)
   const [ctrlTabTarget, setCtrlTabTarget] = useAtom(ctrlTabTargetAtom)
   const [autoAdvanceTarget, setAutoAdvanceTarget] = useAtom(autoAdvanceTargetAtom)
@@ -272,6 +274,21 @@ export function AgentsPreferencesTab() {
             </span>
           </div>
           <Switch checked={soundEnabled} onCheckedChange={setSoundEnabled} />
+        </div>
+        <div className="flex items-center justify-between p-4 border-t border-border">
+          <div className="flex flex-col space-y-1">
+            <span className="text-sm font-medium text-foreground">
+              Notify When Focused
+            </span>
+            <span className="text-xs text-muted-foreground">
+              Show notifications even when the app window is in the foreground
+            </span>
+          </div>
+          <Switch
+            checked={notifyWhenFocused}
+            onCheckedChange={setNotifyWhenFocused}
+            disabled={!desktopNotificationsEnabled}
+          />
         </div>
       </div>
 

--- a/src/renderer/features/agents/main/active-chat.tsx
+++ b/src/renderer/features/agents/main/active-chat.tsx
@@ -6102,10 +6102,13 @@ Make sure to preserve all functionality from both branches when resolving confli
                   // Ignore audio errors
                 }
               }
-
-              // Show native notification (desktop app, when window not focused)
-              notifyAgentComplete(agentChat?.name || "Agent")
             }
+          }
+
+          // Show native notification if not manually aborted
+          // (the hook handles focus/preference checks internally)
+          if (!wasManuallyAborted) {
+            notifyAgentComplete(agentChat?.name || "Agent")
           }
 
           // Refresh diff stats after agent finishes making changes
@@ -6298,10 +6301,13 @@ Make sure to preserve all functionality from both branches when resolving confli
                   // Ignore audio errors
                 }
               }
-
-              // Show native notification (desktop app, when window not focused)
-              notifyAgentComplete(agentChat?.name || "Agent")
             }
+          }
+
+          // Show native notification if not manually aborted
+          // (the hook handles focus/preference checks internally)
+          if (!wasManuallyAborted) {
+            notifyAgentComplete(agentChat?.name || "Agent")
           }
 
           // Refresh diff stats after agent finishes making changes

--- a/src/renderer/lib/atoms/index.ts
+++ b/src/renderer/lib/atoms/index.ts
@@ -396,6 +396,16 @@ export const desktopNotificationsEnabledAtom = atomWithStorage<boolean>(
   { getOnInit: true },
 )
 
+// Preferences - Notify When Focused
+// When enabled, show desktop notifications even when the app window is focused
+// (e.g. when working in a different chat). When disabled, only notify when the app is in the background.
+export const notifyWhenFocusedAtom = atomWithStorage<boolean>(
+  "preferences:notify-when-focused",
+  false,
+  undefined,
+  { getOnInit: true },
+)
+
 // Preferences - Windows Window Frame Style
 // When true, uses native frame (standard Windows title bar)
 // When false, uses frameless window (dark custom title bar)


### PR DESCRIPTION
Main process:
- import Notification statically instead of using require at runtime
- add Notification.isSupported() guard before creating notifications
- skip custom icon on macOS (app icon is used automatically)
- register click handler before calling show() to avoid race condition

Notifications hook:
- add notifyWhenFocused preference to control notifications when app is focused
- apply focus check to notifyAgentComplete, notifyAgentNeedsInput, and notifyPlanReady

Active chat:
- move notifyAgentComplete call outside the sound-enabled block so notifications fire independently of sound preference
- skip notification when agent was manually aborted

Settings UI:
- add "Notify When Focused" toggle to agents preferences tab, disabled when desktop notifications are off

Atoms:
- add notifyWhenFocusedAtom persisted to localStorage (default: false)