### PR TITLE
feat: add AWS Bedrock authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,46 @@ Claude asks clarifying questions, builds structured plans, and shows clean markd
 - **Project Management** - Link local folders with automatic Git remote detection
 - **Integrated Terminal** - Full terminal access within the app
 
+## Authentication Options
+
+1Code supports two authentication methods for accessing Claude API:
+
+### Anthropic OAuth (Default)
+Sign in with your Anthropic account - works seamlessly with Claude.ai Pro subscriptions.
+
+### AWS Bedrock
+
+Use Claude models through AWS Bedrock with your AWS credentials.
+
+**Prerequisites:**
+- AWS account with Bedrock access
+- AWS CLI installed and configured
+- Claude models enabled in AWS Bedrock console
+
+**Setup:**
+
+1. **Configure AWS credentials:**
+   ```bash
+   aws configure
+   # Enter your AWS Access Key ID and Secret Access Key
+   # Choose a region where Bedrock is available (e.g., us-east-1)
+   ```
+
+2. **Enable Bedrock authentication:**
+   - Open 1Code Settings (⌘,)
+   - Go to Authentication tab
+   - Select "AWS Bedrock"
+   - Verify credentials are detected (green checkmark)
+   - Set AWS region
+   - Click "Save Changes"
+
+**Supported AWS Regions:**
+- us-east-1 (N. Virginia)
+- us-west-2 (Oregon)
+- See [AWS Bedrock regions](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html) for the latest availability
+
+**Cost:** AWS Bedrock charges per API request. See [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for details.
+
 ## Installation
 
 ### Option 1: Build from source (free)

--- a/drizzle/0008_lumpy_archangel.sql
+++ b/drizzle/0008_lumpy_archangel.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `anthropic_auth_settings` (
+	`id` text PRIMARY KEY DEFAULT 'singleton' NOT NULL,
+	`auth_mode` text DEFAULT 'oauth' NOT NULL,
+	`aws_region` text DEFAULT 'us-east-1',
+	`aws_profile` text,
+	`updated_at` integer
+);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,482 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2c258ac4-d372-4cd3-9b5a-6613e7338005",
+  "prevId": "b2d2d602-5de1-43b1-ada8-c9ed3edde22d",
+  "tables": {
+    "anthropic_accounts": {
+      "name": "anthropic_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token": {
+          "name": "oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desktop_user_id": {
+          "name": "desktop_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "anthropic_auth_settings": {
+      "name": "anthropic_auth_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'singleton'"
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'oauth'"
+        },
+        "aws_region": {
+          "name": "aws_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'us-east-1'"
+        },
+        "aws_profile": {
+          "name": "aws_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "anthropic_settings": {
+      "name": "anthropic_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'singleton'"
+        },
+        "active_account_id": {
+          "name": "active_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "chats_worktree_path_idx": {
+          "name": "chats_worktree_path_idx",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "claude_code_credentials": {
+      "name": "claude_code_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "oauth_token": {
+          "name": "oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_remote_url": {
+          "name": "git_remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_provider": {
+          "name": "git_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_owner": {
+          "name": "git_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_repo": {
+          "name": "git_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_path": {
+          "name": "icon_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_path_unique": {
+          "name": "projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sub_chats": {
+      "name": "sub_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sub_chats_chat_id_chats_id_fk": {
+          "name": "sub_chats_chat_id_chats_id_fk",
+          "tableFrom": "sub_chats",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1769810815497,
       "tag": "0007_clammy_grim_reaper",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1771309289096,
+      "tag": "0008_lumpy_archangel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/lib/claude/bedrock-validation.ts
+++ b/src/main/lib/claude/bedrock-validation.ts
@@ -1,0 +1,40 @@
+/**
+ * Validate AWS Bedrock configuration before executing Claude query
+ * This ensures users get clear error messages if credentials or config are missing
+ */
+export function validateBedrockConfig(env: Record<string, string>): {
+  valid: boolean
+  error?: string
+  details?: string
+} {
+  // Check for AWS credentials (either env vars or profile)
+  const hasEnvCredentials = !!(
+    env.AWS_ACCESS_KEY_ID && env.AWS_SECRET_ACCESS_KEY
+  )
+  const hasProfile = !!env.AWS_PROFILE
+
+  if (!hasEnvCredentials && !hasProfile) {
+    return {
+      valid: false,
+      error: "AWS credentials not found",
+      details:
+        "Please configure AWS CLI credentials:\n" +
+        "1. Run 'aws configure' in terminal\n" +
+        "2. Or manually edit ~/.aws/credentials\n" +
+        "3. Restart 1Code to load new credentials",
+    }
+  }
+
+  // Check for AWS region
+  if (!env.AWS_REGION && !env.AWS_DEFAULT_REGION) {
+    return {
+      valid: false,
+      error: "AWS region not configured",
+      details:
+        "Please set AWS region in Settings > Authentication.\n" +
+        "Claude on Bedrock is available in regions like us-east-1, us-west-2.",
+    }
+  }
+
+  return { valid: true }
+}

--- a/src/main/lib/db/schema/index.ts
+++ b/src/main/lib/db/schema/index.ts
@@ -128,6 +128,17 @@ export const anthropicSettings = sqliteTable("anthropic_settings", {
   ),
 })
 
+// Stores authentication mode (OAuth vs Bedrock) and AWS configuration
+export const anthropicAuthSettings = sqliteTable("anthropic_auth_settings", {
+  id: text("id").primaryKey().default("singleton"), // Single row
+  authMode: text("auth_mode").notNull().default("oauth"), // "oauth" | "bedrock"
+  awsRegion: text("aws_region").default("us-east-1"),
+  awsProfile: text("aws_profile"), // Optional: override default profile
+  updatedAt: integer("updated_at", { mode: "timestamp" }).$defaultFn(
+    () => new Date(),
+  ),
+})
+
 // ============ TYPE EXPORTS ============
 export type Project = typeof projects.$inferSelect
 export type NewProject = typeof projects.$inferInsert
@@ -140,3 +151,5 @@ export type NewClaudeCodeCredential = typeof claudeCodeCredentials.$inferInsert
 export type AnthropicAccount = typeof anthropicAccounts.$inferSelect
 export type NewAnthropicAccount = typeof anthropicAccounts.$inferInsert
 export type AnthropicSettings = typeof anthropicSettings.$inferSelect
+export type AnthropicAuthSettings = typeof anthropicAuthSettings.$inferSelect
+export type NewAnthropicAuthSettings = typeof anthropicAuthSettings.$inferInsert

--- a/src/main/lib/trpc/routers/anthropic-auth.ts
+++ b/src/main/lib/trpc/routers/anthropic-auth.ts
@@ -1,0 +1,123 @@
+import { z } from "zod"
+import { eq } from "drizzle-orm"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { publicProcedure, router } from "../index"
+import { anthropicAuthSettings, getDatabase } from "../../db"
+
+export const anthropicAuthRouter = router({
+  // Get current authentication settings
+  getSettings: publicProcedure.query(async () => {
+    const db = getDatabase()
+    let settings = db
+      .select()
+      .from(anthropicAuthSettings)
+      .where(eq(anthropicAuthSettings.id, "singleton"))
+      .get()
+
+    // Initialize with defaults if not exists
+    if (!settings) {
+      db.insert(anthropicAuthSettings)
+        .values({
+          id: "singleton",
+          authMode: "oauth",
+          awsRegion: "us-east-1",
+        })
+        .run()
+
+      settings = db
+        .select()
+        .from(anthropicAuthSettings)
+        .where(eq(anthropicAuthSettings.id, "singleton"))
+        .get()
+    }
+
+    return settings
+  }),
+
+  // Update authentication mode and AWS settings
+  updateSettings: publicProcedure
+    .input(
+      z.object({
+        authMode: z.enum(["oauth", "bedrock"]),
+        awsRegion: z.string().optional(),
+        awsProfile: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const db = getDatabase()
+
+      // Upsert settings
+      const existing = db
+        .select()
+        .from(anthropicAuthSettings)
+        .where(eq(anthropicAuthSettings.id, "singleton"))
+        .get()
+
+      if (existing) {
+        db.update(anthropicAuthSettings)
+          .set({
+            authMode: input.authMode,
+            awsRegion: input.awsRegion,
+            awsProfile: input.awsProfile,
+            updatedAt: new Date(),
+          })
+          .where(eq(anthropicAuthSettings.id, "singleton"))
+          .run()
+      } else {
+        db.insert(anthropicAuthSettings)
+          .values({
+            id: "singleton",
+            authMode: input.authMode,
+            awsRegion: input.awsRegion || "us-east-1",
+            awsProfile: input.awsProfile,
+          })
+          .run()
+      }
+
+      console.log(`[anthropic-auth] Auth mode changed to: ${input.authMode}`)
+
+      return db
+        .select()
+        .from(anthropicAuthSettings)
+        .where(eq(anthropicAuthSettings.id, "singleton"))
+        .get()
+    }),
+
+  // Validate AWS credentials are available in environment
+  validateAwsCredentials: publicProcedure.query(async () => {
+    // Check if AWS credentials are available in environment
+    const hasEnvCredentials = !!(
+      process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+    )
+
+    const hasProfile = !!process.env.AWS_PROFILE
+
+    const awsConfigFile =
+      process.env.AWS_CONFIG_FILE || path.join(os.homedir(), ".aws", "config")
+    const awsCredentialsFile =
+      process.env.AWS_SHARED_CREDENTIALS_FILE ||
+      path.join(os.homedir(), ".aws", "credentials")
+
+    const hasConfigFile = fs.existsSync(awsConfigFile)
+    const hasCredentialsFile = fs.existsSync(awsCredentialsFile)
+
+    const hasAwsCredentials =
+      hasEnvCredentials ||
+      hasProfile ||
+      (hasConfigFile && hasCredentialsFile)
+
+    return {
+      hasAwsCredentials,
+      hasEnvCredentials,
+      hasProfile,
+      hasConfigFile,
+      hasCredentialsFile,
+      awsProfile: process.env.AWS_PROFILE || "default",
+      awsRegion: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || null,
+      awsConfigPath: awsConfigFile,
+      awsCredentialsPath: awsCredentialsFile,
+    }
+  }),
+})

--- a/src/main/lib/trpc/routers/index.ts
+++ b/src/main/lib/trpc/routers/index.ts
@@ -5,6 +5,7 @@ import { claudeRouter } from "./claude"
 import { claudeCodeRouter } from "./claude-code"
 import { claudeSettingsRouter } from "./claude-settings"
 import { anthropicAccountsRouter } from "./anthropic-accounts"
+import { anthropicAuthRouter } from "./anthropic-auth"
 import { ollamaRouter } from "./ollama"
 import { codexRouter } from "./codex"
 import { terminalRouter } from "./terminal"
@@ -33,6 +34,7 @@ export function createAppRouter(getWindow: () => BrowserWindow | null) {
     claudeCode: claudeCodeRouter,
     claudeSettings: claudeSettingsRouter,
     anthropicAccounts: anthropicAccountsRouter,
+    anthropicAuth: anthropicAuthRouter,
     ollama: ollamaRouter,
     codex: codexRouter,
     terminal: terminalRouter,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { AgentsLayout } from "./features/layout/agents-layout"
 import {
   AnthropicOnboardingPage,
   ApiKeyOnboardingPage,
+  BedrockOnboardingPage,
   BillingMethodPage,
   CodexOnboardingPage,
   SelectRepoPage,
@@ -19,6 +20,7 @@ import { identify, initAnalytics, shutdown } from "./lib/analytics"
 import {
   anthropicOnboardingCompletedAtom,
   apiKeyOnboardingCompletedAtom,
+  bedrockOnboardingCompletedAtom,
   billingMethodAtom,
   codexOnboardingCompletedAtom,
 } from "./lib/atoms"
@@ -54,6 +56,7 @@ function AppContent() {
   const apiKeyOnboardingCompleted = useAtomValue(apiKeyOnboardingCompletedAtom)
   const setApiKeyOnboardingCompleted = useSetAtom(apiKeyOnboardingCompletedAtom)
   const codexOnboardingCompleted = useAtomValue(codexOnboardingCompletedAtom)
+  const bedrockOnboardingCompleted = useAtomValue(bedrockOnboardingCompletedAtom)
   const selectedProject = useAtomValue(selectedProjectAtom)
   const setSelectedChatId = useSetAtom(selectedAgentChatIdAtom)
   const { setActiveSubChat, addToOpenSubChats, setChatId } = useAgentSubChatStore()
@@ -138,6 +141,10 @@ function AppContent() {
     !apiKeyOnboardingCompleted
   ) {
     return <ApiKeyOnboardingPage />
+  }
+
+  if (billingMethod === "aws-bedrock" && !bedrockOnboardingCompleted) {
+    return <BedrockOnboardingPage />
   }
 
   if (!validatedProject && !isLoadingProjects) {

--- a/src/renderer/components/dialogs/settings-tabs/agents-authentication-tab.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/agents-authentication-tab.tsx
@@ -1,0 +1,268 @@
+import { useState, useEffect } from "react"
+import { trpc } from "../../../lib/trpc"
+import { Label } from "../../ui/label"
+import { Button } from "../../ui/button"
+import { Input } from "../../ui/input"
+import { toast } from "sonner"
+import { CheckCircle2, AlertTriangle, ExternalLink } from "lucide-react"
+
+function useIsNarrowScreen(): boolean {
+  const [isNarrow, setIsNarrow] = useState(false)
+
+  useEffect(() => {
+    const checkWidth = () => {
+      setIsNarrow(window.innerWidth <= 768)
+    }
+
+    checkWidth()
+    window.addEventListener("resize", checkWidth)
+    return () => window.removeEventListener("resize", checkWidth)
+  }, [])
+
+  return isNarrow
+}
+
+export function AgentsAuthenticationTab() {
+  const isNarrowScreen = useIsNarrowScreen()
+
+  const { data: settings, refetch } = trpc.anthropicAuth.getSettings.useQuery()
+  const { data: awsValidation } = trpc.anthropicAuth.validateAwsCredentials.useQuery()
+  const updateMutation = trpc.anthropicAuth.updateSettings.useMutation()
+
+  const [authMode, setAuthMode] = useState<"oauth" | "bedrock">("oauth")
+  const [awsRegion, setAwsRegion] = useState("us-east-1")
+  const [awsProfile, setAwsProfile] = useState("")
+
+  useEffect(() => {
+    if (settings) {
+      setAuthMode(settings.authMode as "oauth" | "bedrock")
+      setAwsRegion(settings.awsRegion || "us-east-1")
+      setAwsProfile(settings.awsProfile || "")
+    }
+  }, [settings])
+
+  const handleSave = async () => {
+    try {
+      await updateMutation.mutateAsync({
+        authMode,
+        awsRegion: authMode === "bedrock" ? awsRegion : undefined,
+        awsProfile: authMode === "bedrock" && awsProfile ? awsProfile : undefined,
+      })
+      await refetch()
+      toast.success("Authentication settings updated")
+    } catch (error) {
+      toast.error("Failed to update settings")
+      console.error(error)
+    }
+  }
+
+  const hasChanges = settings && (
+    authMode !== settings.authMode ||
+    (authMode === "bedrock" && (
+      awsRegion !== (settings.awsRegion || "us-east-1") ||
+      awsProfile !== (settings.awsProfile || "")
+    ))
+  )
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header - hidden on narrow screens */}
+      {!isNarrowScreen && (
+        <div className="space-y-2 pb-3 mb-4">
+          <h3 className="text-sm font-medium text-foreground">Authentication Method</h3>
+          <p className="text-sm text-muted-foreground">
+            Choose how 1Code connects to Claude API
+          </p>
+        </div>
+      )}
+
+      {/* Auth Mode Selection */}
+      <div className="space-y-4">
+        {/* OAuth Option */}
+        <div
+          className={`p-4 border rounded-lg cursor-pointer transition-colors ${
+            authMode === "oauth"
+              ? "border-primary bg-primary/5"
+              : "border-border bg-background hover:bg-muted/50"
+          }`}
+          onClick={() => setAuthMode("oauth")}
+        >
+          <div className="flex items-start space-x-3">
+            <div className={`mt-1 h-4 w-4 rounded-full border-2 flex items-center justify-center ${
+              authMode === "oauth" ? "border-primary" : "border-muted-foreground"
+            }`}>
+              {authMode === "oauth" && (
+                <div className="h-2 w-2 rounded-full bg-primary" />
+              )}
+            </div>
+            <div className="flex-1 space-y-2">
+              <Label className="text-sm font-medium cursor-pointer">
+                Anthropic OAuth (Recommended)
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Sign in with your Anthropic account. Works with Claude.ai subscriptions.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Bedrock Option */}
+        <div
+          className={`p-4 border rounded-lg cursor-pointer transition-colors ${
+            authMode === "bedrock"
+              ? "border-primary bg-primary/5"
+              : "border-border bg-background hover:bg-muted/50"
+          }`}
+          onClick={() => setAuthMode("bedrock")}
+        >
+          <div className="flex items-start space-x-3">
+            <div className={`mt-1 h-4 w-4 rounded-full border-2 flex items-center justify-center ${
+              authMode === "bedrock" ? "border-primary" : "border-muted-foreground"
+            }`}>
+              {authMode === "bedrock" && (
+                <div className="h-2 w-2 rounded-full bg-primary" />
+              )}
+            </div>
+            <div className="flex-1 space-y-3">
+              <div>
+                <Label className="text-sm font-medium cursor-pointer">
+                  AWS Bedrock
+                </Label>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Use AWS CLI credentials from ~/.aws/credentials. Requires Bedrock access.
+                </p>
+              </div>
+
+              {authMode === "bedrock" && (
+                <div className="space-y-4 pt-2" onClick={(e) => e.stopPropagation()}>
+                  {/* AWS Credentials Status */}
+                  {awsValidation && (
+                    <div
+                      className={`p-3 rounded-lg border ${
+                        awsValidation.hasAwsCredentials
+                          ? "border-green-500/50 bg-green-500/10"
+                          : "border-red-500/50 bg-red-500/10"
+                      }`}
+                    >
+                      <div className="flex items-start gap-2">
+                        {awsValidation.hasAwsCredentials ? (
+                          <>
+                            <CheckCircle2 className="h-4 w-4 mt-0.5 text-green-500" />
+                            <div className="flex-1">
+                              <div className="text-sm font-medium text-green-500">
+                                AWS credentials detected
+                              </div>
+                              <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                                <div>Profile: {awsValidation.awsProfile}</div>
+                                {awsValidation.awsRegion && (
+                                  <div>Region: {awsValidation.awsRegion}</div>
+                                )}
+                                {awsValidation.hasCredentialsFile && (
+                                  <div>Credentials file: {awsValidation.awsCredentialsPath}</div>
+                                )}
+                              </div>
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <AlertTriangle className="h-4 w-4 mt-0.5 text-red-500" />
+                            <div className="flex-1">
+                              <div className="text-sm font-medium text-red-500">
+                                No AWS credentials found
+                              </div>
+                              <p className="mt-2 text-sm">
+                                Please configure AWS CLI credentials before enabling Bedrock mode.
+                              </p>
+                              <button
+                                onClick={() =>
+                                  window.desktopApi?.openExternal(
+                                    "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html"
+                                  )
+                                }
+                                className="mt-2 inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+                              >
+                                View AWS CLI setup guide
+                                <ExternalLink className="h-3 w-3" />
+                              </button>
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* AWS Configuration Fields */}
+                  <div className="bg-background rounded-lg border border-border overflow-hidden">
+                    {/* AWS Region */}
+                    <div className="flex items-center justify-between p-4">
+                      <div className="flex-1">
+                        <Label htmlFor="aws-region" className="text-sm font-medium">
+                          AWS Region
+                        </Label>
+                        <p className="text-sm text-muted-foreground mt-1">
+                          Region where Claude on Bedrock is available
+                        </p>
+                      </div>
+                      <div className="flex-shrink-0 w-64">
+                        <Input
+                          id="aws-region"
+                          value={awsRegion}
+                          onChange={(e) => setAwsRegion(e.target.value)}
+                          placeholder="us-east-1"
+                          className="w-full"
+                        />
+                      </div>
+                    </div>
+
+                    {/* AWS Profile (Optional) */}
+                    <div className="flex items-center justify-between p-4 border-t border-border">
+                      <div className="flex-1">
+                        <Label htmlFor="aws-profile" className="text-sm font-medium">
+                          AWS Profile (Optional)
+                        </Label>
+                        <p className="text-sm text-muted-foreground mt-1">
+                          Leave empty to use default profile
+                        </p>
+                      </div>
+                      <div className="flex-shrink-0 w-64">
+                        <Input
+                          id="aws-profile"
+                          value={awsProfile}
+                          onChange={(e) => setAwsProfile(e.target.value)}
+                          placeholder="default"
+                          className="w-full"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Setup Instructions */}
+                  <div className="bg-muted/50 rounded-lg p-4 text-sm space-y-2">
+                    <div className="font-medium">First time using Bedrock?</div>
+                    <ol className="list-decimal list-inside space-y-1 text-muted-foreground">
+                      <li>
+                        Configure AWS CLI:{" "}
+                        <code className="bg-background px-1.5 py-0.5 rounded text-xs">
+                          aws configure
+                        </code>
+                      </li>
+                      <li>Enable Claude models in AWS Bedrock console</li>
+                      <li>Select "AWS Bedrock" above and click "Save Changes"</li>
+                    </ol>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Save Button */}
+      <div className="flex justify-end">
+        <Button onClick={handleSave} disabled={updateMutation.isPending || !hasChanges}>
+          {updateMutation.isPending ? "Saving..." : "Save Changes"}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/features/agents/components/agent-model-selector.tsx
+++ b/src/renderer/features/agents/components/agent-model-selector.tsx
@@ -46,6 +46,7 @@ interface AgentModelSelectorProps {
   onSelectedAgentIdChange: (provider: AgentProviderId) => void
   selectedModelLabel: string
   allowProviderSwitch?: boolean
+  isBedrockMode?: boolean
   triggerClassName?: string
   contentClassName?: string
   claude: {
@@ -79,6 +80,7 @@ export function AgentModelSelector({
   onSelectedAgentIdChange,
   selectedModelLabel,
   allowProviderSwitch = true,
+  isBedrockMode = false,
   triggerClassName,
   contentClassName,
   claude,
@@ -127,8 +129,13 @@ export function AgentModelSelector({
       >
         {showClaudeGroup && (
           <>
-            <div className="px-2.5 py-1.5 mx-1 text-xs font-medium text-muted-foreground">
+            <div className="px-2.5 py-1.5 mx-1 text-xs font-medium text-muted-foreground flex items-center gap-1.5">
               Claude Code
+              {isBedrockMode && (
+                <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 dark:text-amber-400">
+                  Bedrock
+                </span>
+              )}
             </div>
 
             {claude.isOffline && claude.ollamaModels.length > 0 ? (

--- a/src/renderer/features/agents/hooks/use-auth-mode.ts
+++ b/src/renderer/features/agents/hooks/use-auth-mode.ts
@@ -1,0 +1,13 @@
+import { trpc } from "../../../lib/trpc"
+
+export function useAuthMode() {
+  const { data: authSettings } = trpc.anthropicAuth.getSettings.useQuery(
+    undefined,
+    { staleTime: 60 * 1000 }, // 1 minute - auth mode changes rarely
+  )
+  return {
+    authMode: (authSettings?.authMode ?? "oauth") as "oauth" | "bedrock",
+    awsRegion: (authSettings?.awsRegion ?? "us-east-1") as string,
+    isBedrockMode: authSettings?.authMode === "bedrock",
+  }
+}

--- a/src/renderer/features/agents/main/chat-input-area.tsx
+++ b/src/renderer/features/agents/main/chat-input-area.tsx
@@ -41,6 +41,7 @@ import {
   agentsSettingsDialogOpenAtom,
   anthropicOnboardingCompletedAtom,
   apiKeyOnboardingCompletedAtom,
+  bedrockOnboardingCompletedAtom,
   codexApiKeyAtom,
   codexOnboardingCompletedAtom,
   customClaudeConfigAtom,
@@ -91,6 +92,8 @@ import { AgentPastedTextItem } from "../ui/agent-pasted-text-item"
 import { AgentTextContextItem } from "../ui/agent-text-context-item"
 import { VoiceWaveIndicator } from "../ui/voice-wave-indicator"
 import { McpStatusDot } from "../../../components/dialogs/settings-tabs/agents-mcp-tab"
+import { useAuthMode } from "../hooks/use-auth-mode"
+import { ProviderStatusBadge } from "../ui/provider-status-badge"
 import { handlePasteEvent } from "../utils/paste-text"
 import type { PastedTextFile } from "../hooks/use-pasted-text-files"
 import {
@@ -465,6 +468,7 @@ export const ChatInputArea = memo(function ChatInputArea({
   // Connection status for providers
   const anthropicOnboardingCompleted = useAtomValue(anthropicOnboardingCompletedAtom)
   const apiKeyOnboardingCompleted = useAtomValue(apiKeyOnboardingCompletedAtom)
+  const bedrockOnboardingCompleted = useAtomValue(bedrockOnboardingCompletedAtom)
   const codexOnboardingCompleted = useAtomValue(codexOnboardingCompletedAtom)
   const codexUiModels = useMemo(
     () => {
@@ -533,6 +537,9 @@ export const ChatInputArea = memo(function ChatInputArea({
 
   // Extended thinking (reasoning) toggle
   const [thinkingEnabled, setThinkingEnabled] = useAtom(extendedThinkingEnabledAtom)
+
+  // Auth mode (OAuth vs Bedrock)
+  const { isBedrockMode } = useAuthMode()
 
   const selectedModelLabel = useMemo(() => {
     if (provider === "codex") {
@@ -1467,6 +1474,7 @@ export const ChatInputArea = memo(function ChatInputArea({
                         onProviderChange?.(nextProvider)
                       }}
                       allowProviderSwitch={canSwitchProvider}
+                      isBedrockMode={isBedrockMode}
                       selectedModelLabel={selectedModelLabel}
                       claude={{
                         models: availableModels.models.filter((m) => !hiddenModels.includes(m.id)),
@@ -1485,7 +1493,7 @@ export const ChatInputArea = memo(function ChatInputArea({
                         selectedOllamaModel: currentOllamaModel,
                         recommendedOllamaModel: availableModels.recommendedModel,
                         onSelectOllamaModel: setSelectedOllamaModel,
-                        isConnected: anthropicOnboardingCompleted || apiKeyOnboardingCompleted || hasCustomClaudeConfig,
+                        isConnected: anthropicOnboardingCompleted || apiKeyOnboardingCompleted || bedrockOnboardingCompleted || hasCustomClaudeConfig,
                         thinkingEnabled,
                         onThinkingChange: setThinkingEnabled,
                       }}
@@ -1512,6 +1520,8 @@ export const ChatInputArea = memo(function ChatInputArea({
                       }}
                     />
                   </div>
+
+                  <ProviderStatusBadge />
 
                 </div>
 

--- a/src/renderer/features/agents/main/new-chat-form.tsx
+++ b/src/renderer/features/agents/main/new-chat-form.tsx
@@ -55,6 +55,7 @@ import {
   agentsSettingsDialogActiveTabAtom,
   anthropicOnboardingCompletedAtom,
   apiKeyOnboardingCompletedAtom,
+  bedrockOnboardingCompletedAtom,
   codexApiKeyAtom,
   codexOnboardingCompletedAtom,
   customClaudeConfigAtom,
@@ -107,6 +108,7 @@ import {
 import { agentsSidebarOpenAtom, agentsUnseenChangesAtom } from "../atoms"
 import { AgentSendButton } from "../components/agent-send-button"
 import { AgentModelSelector } from "../components/agent-model-selector"
+import { useAuthMode } from "../hooks/use-auth-mode"
 import { CreateBranchDialog } from "../components/create-branch-dialog"
 import { formatTimeAgo } from "../utils/format-time-ago"
 import { handlePasteEvent } from "../utils/paste-text"
@@ -243,7 +245,9 @@ export function NewChatForm({
   // Connection status for providers
   const anthropicOnboardingCompleted = useAtomValue(anthropicOnboardingCompletedAtom)
   const apiKeyOnboardingCompleted = useAtomValue(apiKeyOnboardingCompletedAtom)
+  const bedrockOnboardingCompleted = useAtomValue(bedrockOnboardingCompletedAtom)
   const codexOnboardingCompleted = useAtomValue(codexOnboardingCompletedAtom)
+  const { isBedrockMode } = useAuthMode()
   const setSettingsDialogOpen = useSetAtom(agentsSettingsDialogOpenAtom)
   const setSettingsActiveTab = useSetAtom(agentsSettingsDialogActiveTabAtom)
   const setJustCreatedIds = useSetAtom(justCreatedIdsAtom)
@@ -1874,6 +1878,7 @@ export function NewChatForm({
                             }
                             setLastSelectedAgentId(provider)
                           }}
+                          isBedrockMode={isBedrockMode}
                           selectedModelLabel={selectedModelLabel}
                           claude={{
                             models: availableModels.models.filter((m) => !hiddenModels.includes(m.id)),
@@ -1892,7 +1897,7 @@ export function NewChatForm({
                             selectedOllamaModel: currentOllamaModel,
                             recommendedOllamaModel: availableModels.recommendedModel,
                             onSelectOllamaModel: setSelectedOllamaModel,
-                            isConnected: anthropicOnboardingCompleted || apiKeyOnboardingCompleted || hasCustomClaudeConfig,
+                            isConnected: anthropicOnboardingCompleted || apiKeyOnboardingCompleted || bedrockOnboardingCompleted || hasCustomClaudeConfig,
                             thinkingEnabled,
                             onThinkingChange: setThinkingEnabled,
                           }}

--- a/src/renderer/features/agents/ui/provider-status-badge.tsx
+++ b/src/renderer/features/agents/ui/provider-status-badge.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { useAtomValue } from "jotai"
+import { Cloud } from "lucide-react"
+import { memo } from "react"
+import { Button } from "../../../components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../../../components/ui/tooltip"
+import { ClaudeCodeIcon, KeyFilledIcon } from "../../../components/ui/icons"
+import {
+  billingMethodAtom,
+} from "../../../lib/atoms"
+import { useAuthMode } from "../hooks/use-auth-mode"
+
+/**
+ * Provider Status Badge
+ *
+ * Shows the active authentication provider in the chat input toolbar:
+ * - "Bedrock" with Cloud icon when using AWS Bedrock
+ * - "API Key" with Key icon when using direct API key
+ * - Nothing for default OAuth mode (keeps UI clean)
+ */
+export const ProviderStatusBadge = memo(function ProviderStatusBadge() {
+  const { isBedrockMode, awsRegion } = useAuthMode()
+  const billingMethod = useAtomValue(billingMethodAtom)
+
+  // Only show badge for non-default auth modes
+  if (!isBedrockMode && billingMethod !== "api-key" && billingMethod !== "custom-model") {
+    return null
+  }
+
+  if (isBedrockMode) {
+    return (
+      <Tooltip delayDuration={500}>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 gap-1.5 text-xs text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 transition-colors rounded-md cursor-default"
+            aria-label="AWS Bedrock"
+          >
+            <Cloud className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>Bedrock</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Connected via AWS Bedrock ({awsRegion})
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  if (billingMethod === "api-key") {
+    return (
+      <Tooltip delayDuration={500}>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors rounded-md cursor-default"
+            aria-label="API Key"
+          >
+            <KeyFilledIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>API Key</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Connected via Anthropic API Key
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  if (billingMethod === "custom-model") {
+    return (
+      <Tooltip delayDuration={500}>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors rounded-md cursor-default"
+            aria-label="Custom Model"
+          >
+            <ClaudeCodeIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>Custom</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Connected via custom model configuration
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return null
+})

--- a/src/renderer/features/onboarding/bedrock-onboarding-page.tsx
+++ b/src/renderer/features/onboarding/bedrock-onboarding-page.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import { useSetAtom } from "jotai"
+import { useState } from "react"
+import { ChevronLeft, Cloud, CheckCircle2, AlertCircle } from "lucide-react"
+
+import { IconSpinner } from "../../components/ui/icons"
+import { Input } from "../../components/ui/input"
+import { Label } from "../../components/ui/label"
+import { Logo } from "../../components/ui/logo"
+import {
+  bedrockOnboardingCompletedAtom,
+  billingMethodAtom,
+} from "../../lib/atoms"
+import { trpc } from "../../lib/trpc"
+import { cn } from "../../lib/utils"
+
+export function BedrockOnboardingPage() {
+  const setBillingMethod = useSetAtom(billingMethodAtom)
+  const setBedrockOnboardingCompleted = useSetAtom(bedrockOnboardingCompletedAtom)
+
+  const [region, setRegion] = useState("us-east-1")
+  const [profile, setProfile] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Validate AWS credentials via backend
+  const { data: validation, isLoading: isValidating } =
+    trpc.anthropicAuth.validateAwsCredentials.useQuery(undefined, {
+      staleTime: 10 * 1000,
+    })
+
+  const updateSettings = trpc.anthropicAuth.updateSettings.useMutation()
+
+  const handleBack = () => {
+    setBillingMethod(null)
+  }
+
+  const handleConnect = async () => {
+    setIsSubmitting(true)
+    try {
+      await updateSettings.mutateAsync({
+        authMode: "bedrock",
+        awsRegion: region.trim() || "us-east-1",
+        awsProfile: profile.trim() || undefined,
+      })
+      setBedrockOnboardingCompleted(true)
+    } catch (error) {
+      console.error("[bedrock-onboarding] Failed to save settings:", error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const hasCredentials = validation?.hasAwsCredentials ?? false
+  const canSubmit = region.trim().length > 0
+
+  return (
+    <div className="h-screen w-screen flex flex-col items-center justify-center bg-background select-none">
+      {/* Draggable title bar area */}
+      <div
+        className="fixed top-0 left-0 right-0 h-10"
+        style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+      />
+
+      {/* Back button */}
+      <button
+        onClick={handleBack}
+        className="fixed top-12 left-4 flex items-center justify-center h-8 w-8 rounded-full hover:bg-foreground/5 transition-colors"
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </button>
+
+      <div className="w-full max-w-[440px] space-y-8 px-4">
+        {/* Header */}
+        <div className="text-center space-y-4">
+          <div className="flex items-center justify-center gap-2 p-2 mx-auto w-max rounded-full border border-border">
+            <div className="w-10 h-10 rounded-full bg-primary flex items-center justify-center">
+              <Logo className="w-5 h-5" fill="white" />
+            </div>
+            <div className="w-10 h-10 rounded-full bg-amber-600 flex items-center justify-center">
+              <Cloud className="w-5 h-5 text-white" />
+            </div>
+          </div>
+          <div className="space-y-1">
+            <h1 className="text-base font-semibold tracking-tight">
+              Connect AWS Bedrock
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Use Claude models via your AWS account
+            </p>
+          </div>
+        </div>
+
+        {/* Credential Status */}
+        <div
+          className={cn(
+            "flex items-center gap-3 p-3 rounded-lg border",
+            isValidating
+              ? "border-border bg-muted/30"
+              : hasCredentials
+                ? "border-green-500/30 bg-green-500/5"
+                : "border-amber-500/30 bg-amber-500/5",
+          )}
+        >
+          {isValidating ? (
+            <IconSpinner className="h-4 w-4 shrink-0" />
+          ) : hasCredentials ? (
+            <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />
+          ) : (
+            <AlertCircle className="h-4 w-4 shrink-0 text-amber-500" />
+          )}
+          <div className="text-sm">
+            {isValidating ? (
+              <span className="text-muted-foreground">
+                Checking AWS credentials...
+              </span>
+            ) : hasCredentials ? (
+              <span className="text-green-600 dark:text-green-400">
+                AWS credentials detected
+                {validation?.hasEnvCredentials
+                  ? " (environment variables)"
+                  : validation?.hasProfile
+                    ? ` (profile: ${validation.awsProfile})`
+                    : " (~/.aws/credentials)"}
+              </span>
+            ) : (
+              <span className="text-amber-600 dark:text-amber-400">
+                No AWS credentials found. Run{" "}
+                <code className="bg-muted px-1 py-0.5 rounded text-xs">
+                  aws configure
+                </code>{" "}
+                or set environment variables.
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Form Fields */}
+        <div className="space-y-4">
+          {/* AWS Region */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">AWS Region</Label>
+            <Input
+              value={region}
+              onChange={(e) => setRegion(e.target.value)}
+              placeholder="us-east-1"
+              className="w-full"
+            />
+            <p className="text-xs text-muted-foreground">
+              Region where Bedrock is enabled (e.g. us-east-1, us-west-2, eu-west-1)
+            </p>
+          </div>
+
+          {/* AWS Profile (optional) */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              AWS Profile{" "}
+              <span className="text-muted-foreground font-normal">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              value={profile}
+              onChange={(e) => setProfile(e.target.value)}
+              placeholder="default"
+              className="w-full"
+            />
+            <p className="text-xs text-muted-foreground">
+              Named profile from ~/.aws/credentials. Leave empty for default.
+            </p>
+          </div>
+        </div>
+
+        {/* Connect Button */}
+        <button
+          onClick={handleConnect}
+          disabled={!canSubmit || isSubmitting}
+          className={cn(
+            "w-full h-8 px-3 bg-primary text-primary-foreground rounded-lg text-sm font-medium transition-[background-color,transform] duration-150 hover:bg-primary/90 active:scale-[0.97] shadow-[0_0_0_0.5px_rgb(23,23,23),inset_0_0_0_1px_rgba(255,255,255,0.14)] dark:shadow-[0_0_0_0.5px_rgb(23,23,23),inset_0_0_0_1px_rgba(255,255,255,0.14)] flex items-center justify-center",
+            (!canSubmit || isSubmitting) && "opacity-50 cursor-not-allowed",
+          )}
+        >
+          {isSubmitting ? <IconSpinner className="h-4 w-4" /> : "Connect"}
+        </button>
+
+        {/* Help text */}
+        <p className="text-xs text-muted-foreground text-center">
+          Requires AWS CLI configured with{" "}
+          <code className="bg-muted px-1 py-0.5 rounded">aws configure</code>{" "}
+          or AWS environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/features/onboarding/billing-method-page.tsx
+++ b/src/renderer/features/onboarding/billing-method-page.tsx
@@ -4,6 +4,7 @@ import { useSetAtom } from "jotai"
 import { Check } from "lucide-react"
 import { useMemo, useState } from "react"
 
+import { Cloud } from "lucide-react"
 import {
   ClaudeCodeIcon,
   CodexIcon,
@@ -54,6 +55,14 @@ const billingOptions: BillingOption[] = [
     title: "Custom Model",
     subtitle: "Use a custom base URL and model.",
     icon: <SettingsFilledIcon className="w-5 h-5" />,
+  },
+  {
+    id: "aws-bedrock",
+    method: "aws-bedrock",
+    group: "claude-code",
+    title: "AWS Bedrock",
+    subtitle: "Use Claude via your AWS account credentials.",
+    icon: <Cloud className="w-5 h-5" />,
   },
   {
     id: "codex-subscription",

--- a/src/renderer/features/onboarding/index.ts
+++ b/src/renderer/features/onboarding/index.ts
@@ -1,5 +1,6 @@
 export { AnthropicOnboardingPage } from "./anthropic-onboarding-page"
 export { ApiKeyOnboardingPage } from "./api-key-onboarding-page"
+export { BedrockOnboardingPage } from "./bedrock-onboarding-page"
 export { BillingMethodPage } from "./billing-method-page"
 export { CodexOnboardingPage } from "./codex-onboarding-page"
 export { SelectRepoPage } from "./select-repo-page"

--- a/src/renderer/features/settings/settings-content.tsx
+++ b/src/renderer/features/settings/settings-content.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../lib/atoms"
 import { desktopViewAtom } from "../agents/atoms"
 import { AgentsAppearanceTab } from "../../components/dialogs/settings-tabs/agents-appearance-tab"
+import { AgentsAuthenticationTab } from "../../components/dialogs/settings-tabs/agents-authentication-tab"
 import { AgentsBetaTab } from "../../components/dialogs/settings-tabs/agents-beta-tab"
 import { AgentsCustomAgentsTab } from "../../components/dialogs/settings-tabs/agents-custom-agents-tab"
 import { AgentsDebugTab } from "../../components/dialogs/settings-tabs/agents-debug-tab"
@@ -43,6 +44,8 @@ export function SettingsContent() {
     switch (activeTab) {
       case "profile":
         return <AgentsProfileTab />
+      case "authentication":
+        return <AgentsAuthenticationTab />
       case "appearance":
         return <AgentsAppearanceTab />
       case "keyboard":

--- a/src/renderer/features/settings/settings-sidebar.tsx
+++ b/src/renderer/features/settings/settings-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   FlaskFilledIcon,
   FolderFilledIcon,
   KeyboardFilledIcon,
+  KeyFilledIcon,
   OriginalMCPIcon,
   PluginFilledIcon,
   SkillIconFilled,
@@ -43,6 +44,11 @@ const MAIN_TABS = [
     id: "profile" as SettingsTab,
     label: "Account",
     icon: ProfileIconFilled,
+  },
+  {
+    id: "authentication" as SettingsTab,
+    label: "Authentication",
+    icon: KeyFilledIcon,
   },
   {
     id: "appearance" as SettingsTab,

--- a/src/renderer/lib/atoms/index.ts
+++ b/src/renderer/lib/atoms/index.ts
@@ -183,6 +183,7 @@ export const clearSubChatSelectionAtom = atom(null, (_get, set) => {
 // Settings dialog
 export type SettingsTab =
   | "profile"
+  | "authentication"
   | "appearance"
   | "preferences"
   | "models"
@@ -742,6 +743,7 @@ export type BillingMethod =
   | "claude-subscription"
   | "api-key"
   | "custom-model"
+  | "aws-bedrock"
   | "codex-subscription"
   | "codex-api-key"
   | null
@@ -767,6 +769,15 @@ export const anthropicOnboardingCompletedAtom = atomWithStorage<boolean>(
 // Only relevant when billingMethod is "api-key"
 export const apiKeyOnboardingCompletedAtom = atomWithStorage<boolean>(
   "onboarding:api-key-completed",
+  false,
+  undefined,
+  { getOnInit: true },
+)
+
+// Whether user has completed AWS Bedrock configuration during onboarding
+// Only relevant when billingMethod is "aws-bedrock"
+export const bedrockOnboardingCompletedAtom = atomWithStorage<boolean>(
+  "onboarding:bedrock-completed",
   false,
   undefined,
   { getOnInit: true },


### PR DESCRIPTION
## Summary

- Adds AWS Bedrock as an alternative authentication method alongside Anthropic OAuth
- Users can access Claude models through their existing AWS credentials (`~/.aws/credentials` or environment variables)
- Includes full onboarding flow, settings UI, and visual indicators when Bedrock is active

## Changes

**Backend (main process):**
- Remove `CLAUDE_CODE_USE_BEDROCK` from stripped env vars so the SDK can use it
- Conditionally preserve/strip AWS credentials based on auth mode (Bedrock preserves, OAuth strips for security)
- New `anthropic_auth_settings` DB table + Drizzle migration for persisting auth mode preference
- New `anthropicAuth` tRPC router with `getSettings`, `updateSettings`, and `validateAwsCredentials` procedures
- Bedrock credential validation before executing SDK queries

**Onboarding:**
- "AWS Bedrock" option added to billing method page (Claude Code tab)
- Dedicated Bedrock onboarding page with AWS region/profile configuration
- Real-time credential detection (checks env vars, `~/.aws/credentials`, named profiles)

**Settings:**
- New "Authentication" tab to switch between OAuth and Bedrock modes
- Shows credential status, configurable region and profile

**UI indicators:**
- Provider status badge in chat toolbar showing "Bedrock" (amber), "API Key", or "Custom"
- "Bedrock" tag in model selector dropdown next to "Claude Code" header
- Updated `isConnected` checks so Claude models appear when Bedrock auth is configured

## Security

- AWS credentials are never stored in the database — only auth mode, region, and profile name
- MCP subprocess isolation unchanged (AWS credentials still blocked for MCP servers via `mcp-auth.ts`)
- OAuth mode continues to strip AWS credentials for security
- No secrets exposed in any source files

## Test plan

- [ ] Fresh install: select "AWS Bedrock" in onboarding, configure region, verify credential detection works
- [ ] Existing OAuth user: switch to Bedrock in Settings > Authentication, verify chat works
- [ ] Switch back to OAuth: verify badges disappear and OAuth flow resumes normally
- [ ] Model selector: verify "Bedrock" tag appears next to "Claude Code" when Bedrock is active
- [ ] Provider badge: verify "Bedrock" with region tooltip shows in chat toolbar
- [ ] No credentials in build: verify `bun run build` succeeds with no exposed secrets