### PR TITLE
fix: add RubyMine to Preferred Editor dropdown

### DIFF
--- a/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
@@ -30,6 +30,7 @@ import phpstormIcon from "../../../assets/app-icons/phpstorm.svg"
 import golandIcon from "../../../assets/app-icons/goland.svg"
 import clionIcon from "../../../assets/app-icons/clion.svg"
 import riderIcon from "../../../assets/app-icons/rider.svg"
+import rubymineIcon from "../../../assets/app-icons/rubymine.svg"
 import fleetIcon from "../../../assets/app-icons/fleet.svg"
 import rustroverIcon from "../../../assets/app-icons/rustrover.svg"
 import windsurfIcon from "../../../assets/app-icons/windsurf.svg"
@@ -59,6 +60,7 @@ const EDITOR_ICONS: Partial<Record<ExternalApp, string>> = {
   goland: golandIcon,
   clion: clionIcon,
   rider: riderIcon,
+  rubymine: rubymineIcon,
   fleet: fleetIcon,
   rustrover: rustroverIcon,
 }
@@ -98,6 +100,7 @@ const JETBRAINS: EditorOption[] = [
   { id: "goland", label: "GoLand" },
   { id: "clion", label: "CLion" },
   { id: "rider", label: "Rider" },
+  { id: "rubymine", label: "RubyMine" },
   { id: "fleet", label: "Fleet" },
   { id: "rustrover", label: "RustRover" },
 ]


### PR DESCRIPTION
Fixes #177

RubyMine is fully defined in `src/shared/external-apps.ts` and has an icon at `src/renderer/assets/app-icons/rubymine.svg`, but was missing from the `JETBRAINS` array in `agents-preferences-tab.tsx`.

Changes:
- import `rubymine.svg` icon
- add `rubymine` entry to `EDITOR_ICONS`
- add `{ id: "rubymine", label: "RubyMine" }` to the `JETBRAINS` array

Co-Authored-By: Claude <noreply@anthropic.com>