### PR TITLE
Swap Enter/Shift+Enter in agents prompt editor

### DIFF
--- a/src/renderer/features/agents/main/active-chat.tsx
+++ b/src/renderer/features/agents/main/active-chat.tsx
@@ -4178,7 +4178,7 @@ const ChatViewInner = memo(function ChatViewInner({
     removeFromQueue(subChatId, itemId)
   }, [subChatId, removeFromQueue])
 
-  // Force send - stop stream and send immediately, bypassing queue (Opt+Enter)
+  // Force send - stop stream and send immediately, bypassing queue (Opt+Shift+Enter)
   const handleForceSend = useCallback(async () => {
     // Block sending while sandbox is still being set up
     if (sandboxSetupStatus !== "ready") {

--- a/src/renderer/features/agents/main/chat-input-area.tsx
+++ b/src/renderer/features/agents/main/chat-input-area.tsx
@@ -151,7 +151,7 @@ export interface ChatInputAreaProps {
   fileInputRef: React.RefObject<HTMLInputElement | null>
   // Core callbacks
   onSend: () => void
-  onForceSend: () => void // Opt+Enter: stop stream and send immediately, bypassing queue
+  onForceSend: () => void // Opt+Shift+Enter: stop stream and send immediately, bypassing queue
   onStop: () => Promise<void>
   onCompact: () => void
   onCreateNewSubChat?: () => void
@@ -1075,7 +1075,7 @@ export const ChatInputArea = memo(function ChatInputArea({
       }
 
       // For all other commands (builtin prompts and custom):
-      // insert the command and let user add arguments or press Enter to send
+      // insert the command and let user add arguments or press Shift+Enter to send
       editorRef.current?.setValue(`/${command.name} `)
     },
     [subChatMode, updateMode, onCreateNewSubChat, onCompact, editorRef],

--- a/src/renderer/features/agents/main/new-chat-form.tsx
+++ b/src/renderer/features/agents/main/new-chat-form.tsx
@@ -1386,7 +1386,7 @@ export function NewChatForm({
       }
 
       // For all other commands (builtin prompts and custom):
-      // insert the command and let user add arguments or press Enter to send
+      // insert the command and let user add arguments or press Shift+Enter to send
       editorRef.current?.setValue(`/${command.name} `)
     },
     [agentMode],

--- a/src/renderer/features/agents/mentions/agents-mentions-editor.tsx
+++ b/src/renderer/features/agents/mentions/agents-mentions-editor.tsx
@@ -75,7 +75,7 @@ type AgentsMentionsEditorProps = {
   placeholder?: string
   className?: string
   onSubmit?: () => void
-  onForceSubmit?: () => void // Opt+Enter: bypass queue, stop stream and send immediately
+  onForceSubmit?: () => void // Opt+Shift+Enter: bypass queue, stop stream and send immediately
   disabled?: boolean
   onPaste?: (e: React.ClipboardEvent) => void
   onShiftTab?: () => void // callback for Shift+Tab (e.g., mode switching)
@@ -1042,13 +1042,13 @@ export const AgentsMentionsEditor = memo(
           }
 
           // Prevent submission during IME composition (e.g., Chinese/Japanese/Korean input)
-          if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+          if (e.key === "Enter" && e.shiftKey && !e.nativeEvent.isComposing) {
             if (triggerActive.current || slashTriggerActive.current) {
               // Let dropdown handle Enter
               return
             }
             e.preventDefault()
-            // Opt+Enter = force submit (bypass queue, stop stream and send immediately)
+            // Opt+Shift+Enter = force submit (bypass queue, stop stream and send immediately)
             if (e.altKey && onForceSubmit) {
               onForceSubmit()
             } else {


### PR DESCRIPTION
## Summary

Swap the submit/newline keys in the shared `AgentsMentionsEditor`:

- **Enter** → insert a newline (default contenteditable behavior)
- **Shift+Enter** → submit
- **Opt+Shift+Enter** → force-submit (stop current stream, bypass queue, send immediately)

Applies to both the new-workspace ("What do you want to get done?") input and the active-chat input, since both render the same editor.

Closes #197

## Why

Multi-line prompts were easy to accidentally send with a stray Enter. Making Enter a newline and requiring a modifier to submit matches the pattern users already expect from other chat UIs for longer-form composition.

## Changes

- `src/renderer/features/agents/mentions/agents-mentions-editor.tsx` — flipped the `shiftKey` check in the Enter branch of the editor's `onKeyDown` handler (the core one-line behavior change). Plain Enter now falls through to the native contenteditable newline; dropdown (`@` mention / `/` slash) handling is unchanged.
- Updated comments in `chat-input-area.tsx`, `active-chat.tsx`, and `new-chat-form.tsx` so any "Opt+Enter" / "press Enter to send" references now say "Opt+Shift+Enter" / "press Shift+Enter to send".

IME composition (`isComposing`) guard is preserved — composing in CJK IMEs still commits on Enter without submitting.

## Test plan

- [ ] **New workspace**: select a project, type text, press Enter → newline; press Shift+Enter → submits multi-line prompt
- [ ] **Active chat**: same Enter/Shift+Enter behavior
- [ ] **Mentions / slash**: typing `@` then Enter still selects mention; typing `/` then Enter still selects command
- [ ] **Force-submit**: during an in-flight stream, Opt+Shift+Enter stops the stream and sends immediately
- [ ] **IME**: commit a CJK composition with Enter — composition commits, no submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)