### PR TITLE
feat(agents): add Claude thinking effort selector

### DIFF
--- a/src/main/lib/trpc/routers/claude.ts
+++ b/src/main/lib/trpc/routers/claude.ts
@@ -810,7 +810,9 @@ export const claudeRouter = router({
             baseUrl: z.string().min(1),
           })
           .optional(),
-        maxThinkingTokens: z.number().optional(), // Enable extended thinking
+        effort: z
+          .enum(["low", "medium", "high", "xhigh", "max"])
+          .optional(), // Thinking/reasoning effort level
         images: z.array(imageAttachmentSchema).optional(), // Image attachments
         historyEnabled: z.boolean().optional(),
         offlineModeEnabled: z.boolean().optional(), // Whether offline mode (Ollama) is enabled in settings
@@ -1994,9 +1996,7 @@ ${prompt}
                 ...(!resumeSessionId && { continue: true }),
                 ...(resolvedModel && { model: resolvedModel }),
                 // fallbackModel: "claude-opus-4-5-20251101",
-                ...(input.maxThinkingTokens && {
-                  maxThinkingTokens: input.maxThinkingTokens,
-                }),
+                ...(input.effort && { effort: input.effort }),
               },
             }
 

--- a/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
+++ b/src/renderer/components/dialogs/settings-tabs/agents-preferences-tab.tsx
@@ -6,7 +6,6 @@ import {
   ctrlTabTargetAtom,
   defaultAgentModeAtom,
   desktopNotificationsEnabledAtom,
-  extendedThinkingEnabledAtom,
   notifyWhenFocusedAtom,
   soundNotificationsEnabledAtom,
   preferredEditorAtom,
@@ -14,6 +13,11 @@ import {
   type AutoAdvanceTarget,
   type CtrlTabTarget,
 } from "../../../lib/atoms"
+import { lastSelectedClaudeThinkingAtom } from "../../../features/agents/atoms"
+import {
+  formatClaudeThinkingLabel,
+  type ClaudeThinkingLevel,
+} from "../../../features/agents/lib/models"
 import { APP_META, type ExternalApp } from "../../../../shared/external-apps"
 
 // Editor icon imports
@@ -142,8 +146,8 @@ function useIsNarrowScreen(): boolean {
 }
 
 export function AgentsPreferencesTab() {
-  const [thinkingEnabled, setThinkingEnabled] = useAtom(
-    extendedThinkingEnabledAtom,
+  const [claudeThinking, setClaudeThinking] = useAtom(
+    lastSelectedClaudeThinkingAtom,
   )
   const [soundEnabled, setSoundEnabled] = useAtom(soundNotificationsEnabledAtom)
   const [desktopNotificationsEnabled, setDesktopNotificationsEnabled] = useAtom(desktopNotificationsEnabledAtom)
@@ -197,18 +201,34 @@ export function AgentsPreferencesTab() {
         <div className="flex items-center justify-between p-4">
           <div className="flex flex-col space-y-1">
             <span className="text-sm font-medium text-foreground">
-              Extended Thinking
+              Thinking Effort
             </span>
             <span className="text-xs text-muted-foreground">
-              Enable deeper reasoning with more thinking tokens (uses more
-              credits).{" "}
-              <span className="text-foreground/70">Disables response streaming.</span>
+              Default effort level for Claude's reasoning. Higher levels think
+              longer and use more credits.
             </span>
           </div>
-          <Switch
-            checked={thinkingEnabled}
-            onCheckedChange={setThinkingEnabled}
-          />
+          <Select
+            value={claudeThinking}
+            onValueChange={(value: ClaudeThinkingLevel) =>
+              setClaudeThinking(value)
+            }
+          >
+            <SelectTrigger className="w-auto px-2">
+              <span className="text-xs">
+                {formatClaudeThinkingLabel(claudeThinking)}
+              </span>
+            </SelectTrigger>
+            <SelectContent>
+              {(
+                ["off", "low", "medium", "high", "xhigh", "max"] as const
+              ).map((level) => (
+                <SelectItem key={level} value={level}>
+                  {formatClaudeThinkingLabel(level)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="flex items-center justify-between p-4 border-t border-border">
           <div className="flex flex-col space-y-1">

--- a/src/renderer/features/agents/atoms/index.ts
+++ b/src/renderer/features/agents/atoms/index.ts
@@ -234,6 +234,34 @@ export const lastSelectedCodexThinkingAtom = atomWithStorage<CodexThinkingPrefer
   { getOnInit: true },
 )
 
+export type ClaudeThinkingPreference =
+  | "off"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+
+// One-time migration from the legacy boolean toggle: true → "high", false → "off".
+// Only consulted the first time the new key is read (atomWithStorage keeps the user's
+// choice thereafter).
+function readInitialClaudeThinking(): ClaudeThinkingPreference {
+  try {
+    const raw = localStorage.getItem("preferences:extended-thinking-enabled")
+    if (raw === null) return "high"
+    return JSON.parse(raw) === false ? "off" : "high"
+  } catch {
+    return "high"
+  }
+}
+
+export const lastSelectedClaudeThinkingAtom = atomWithStorage<ClaudeThinkingPreference>(
+  "agents:lastSelectedClaudeThinking",
+  readInitialClaudeThinking(),
+  undefined,
+  { getOnInit: true },
+)
+
 // Storage for per-subChat Claude model selection.
 // Falls back to lastSelectedModelIdAtom when sub-chat has no explicit selection yet.
 const subChatModelIdsStorageAtom = atomWithStorage<Record<string, string>>(
@@ -319,6 +347,38 @@ export const subChatCodexThinkingAtomFamily = atomFamily((subChatId: string) =>
       const current = get(subChatCodexThinkingStorageAtom)
       if (current[subChatId] === newThinking) return
       set(subChatCodexThinkingStorageAtom, { ...current, [subChatId]: newThinking })
+    },
+  ),
+)
+
+// Storage for per-subChat Claude thinking level.
+// Falls back to lastSelectedClaudeThinkingAtom when sub-chat has no explicit selection yet.
+const subChatClaudeThinkingStorageAtom = atomWithStorage<
+  Record<string, ClaudeThinkingPreference>
+>(
+  "agents:subChatClaudeThinking",
+  {},
+  undefined,
+  { getOnInit: true },
+)
+
+export const subChatClaudeThinkingAtomFamily = atomFamily((subChatId: string) =>
+  atom(
+    (get) => {
+      if (!subChatId) return get(lastSelectedClaudeThinkingAtom)
+      return (
+        get(subChatClaudeThinkingStorageAtom)[subChatId] ??
+        get(lastSelectedClaudeThinkingAtom)
+      )
+    },
+    (get, set, newThinking: ClaudeThinkingPreference) => {
+      if (!subChatId) {
+        set(lastSelectedClaudeThinkingAtom, newThinking)
+        return
+      }
+      const current = get(subChatClaudeThinkingStorageAtom)
+      if (current[subChatId] === newThinking) return
+      set(subChatClaudeThinkingStorageAtom, { ...current, [subChatId]: newThinking })
     },
   ),
 )

--- a/src/renderer/features/agents/components/agent-model-selector.tsx
+++ b/src/renderer/features/agents/components/agent-model-selector.tsx
@@ -13,8 +13,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "../../../components/ui/command"
-import { CheckIcon, ClaudeCodeIcon, IconChevronDown, ThinkingIcon } from "../../../components/ui/icons"
-import { Switch } from "../../../components/ui/switch"
+import { CheckIcon, ClaudeCodeIcon, IconChevronDown } from "../../../components/ui/icons"
 import { Checkbox } from "../../../components/ui/checkbox"
 import { Button } from "../../../components/ui/button"
 import {
@@ -23,8 +22,11 @@ import {
   PopoverTrigger,
 } from "../../../components/ui/popover"
 import { cn } from "../../../lib/utils"
-import type { CodexThinkingLevel } from "../lib/models"
-import { formatCodexThinkingLabel } from "../lib/models"
+import type { ClaudeThinkingLevel, CodexThinkingLevel } from "../lib/models"
+import {
+  formatClaudeThinkingLabel,
+  formatCodexThinkingLabel,
+} from "../lib/models"
 
 const CROSS_PROVIDER_DIALOG_DISMISSED_KEY = "agent-model-selector:skip-cross-provider-dialog"
 
@@ -40,6 +42,7 @@ type ClaudeModelOption = {
   id: string
   name: string
   version: string
+  thinkings: ClaudeThinkingLevel[]
 }
 
 type CodexModelOption = {
@@ -70,8 +73,8 @@ interface AgentModelSelectorProps {
     recommendedOllamaModel?: string
     onSelectOllamaModel: (modelId: string) => void
     isConnected: boolean
-    thinkingEnabled: boolean
-    onThinkingChange: (enabled: boolean) => void
+    selectedThinking: ClaudeThinkingLevel
+    onSelectThinking: (thinking: ClaudeThinkingLevel) => void
   }
   codex: {
     models: CodexModelOption[]
@@ -89,14 +92,16 @@ type FlatModelItem =
   | { type: "ollama"; modelName: string; isRecommended: boolean }
   | { type: "custom" }
 
-function CodexThinkingSubMenu({
-  thinkings,
-  selectedThinking,
-  onSelectThinking,
+function ThinkingSubMenu<T extends string>({
+  levels,
+  selected,
+  onSelect,
+  formatLabel,
 }: {
-  thinkings: CodexThinkingLevel[]
-  selectedThinking: CodexThinkingLevel
-  onSelectThinking: (thinking: CodexThinkingLevel) => void
+  levels: T[]
+  selected: T
+  onSelect: (level: T) => void
+  formatLabel: (level: T) => string
 }) {
   const triggerRef = useRef<HTMLDivElement>(null)
   const subMenuRef = useRef<HTMLDivElement>(null)
@@ -167,9 +172,7 @@ function CodexThinkingSubMenu({
           <span>Thinking</span>
         </div>
         <div className="flex items-center gap-1 text-muted-foreground">
-          <span className="text-xs">
-            {formatCodexThinkingLabel(selectedThinking)}
-          </span>
+          <span className="text-xs">{formatLabel(selected)}</span>
           <ChevronRight className="h-3.5 w-3.5 shrink-0" />
         </div>
       </div>
@@ -183,15 +186,15 @@ function CodexThinkingSubMenu({
             className="fixed z-50 min-w-[180px] overflow-auto rounded-[10px] border border-border bg-popover text-sm text-popover-foreground shadow-lg py-1 animate-in fade-in-0 zoom-in-95 slide-in-from-left-2"
             style={{ top: subPos.top, left: subPos.left }}
           >
-            {thinkings.map((thinking) => {
-              const isSelected = selectedThinking === thinking
+            {levels.map((level) => {
+              const isSelected = selected === level
               return (
                 <button
-                  key={thinking}
-                  onClick={() => onSelectThinking(thinking)}
+                  key={level}
+                  onClick={() => onSelect(level)}
                   className="flex items-center justify-between gap-4 min-h-[32px] py-[5px] px-1.5 mx-1 w-[calc(100%-8px)] rounded-md text-sm cursor-default select-none outline-none dark:hover:bg-neutral-800 hover:text-foreground transition-colors"
                 >
-                  <span>{formatCodexThinkingLabel(thinking)}</span>
+                  <span>{formatLabel(level)}</span>
                   {isSelected && (
                     <CheckIcon className="h-3.5 w-3.5 shrink-0" />
                   )}
@@ -558,28 +561,27 @@ export function AgentModelSelector({
             onValueChange={setSearch}
           />
 
-          {/* Claude thinking toggle */}
+          {/* Claude thinking effort selector with hover sub-menu */}
           {selectedAgentId === "claude-code" &&
             !claude.isOffline &&
-            !claude.hasCustomModelConfig && (
-            <>
-              <div
-                className="flex items-center justify-between min-h-[32px] py-[5px] px-1.5 mx-1"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div className="flex items-center gap-1.5">
-                  <ThinkingIcon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                  <span className="text-sm">Thinking</span>
-                </div>
-                <Switch
-                  checked={claude.thinkingEnabled}
-                  onCheckedChange={claude.onThinkingChange}
-                  className="scale-75"
-                />
-              </div>
-              <CommandSeparator />
-            </>
-          )}
+            !claude.hasCustomModelConfig &&
+            (() => {
+              const selectedClaudeModel =
+                claude.models.find((m) => m.id === claude.selectedModelId) ||
+                claude.models[0]
+              if (!selectedClaudeModel) return null
+              return (
+                <>
+                  <ThinkingSubMenu<ClaudeThinkingLevel>
+                    levels={selectedClaudeModel.thinkings}
+                    selected={claude.selectedThinking}
+                    onSelect={claude.onSelectThinking}
+                    formatLabel={formatClaudeThinkingLabel}
+                  />
+                  <CommandSeparator />
+                </>
+              )
+            })()}
 
           {/* Codex thinking level selector with hover sub-menu */}
           {selectedAgentId === "codex" && (() => {
@@ -587,10 +589,11 @@ export function AgentModelSelector({
             if (!selectedCodexModel) return null
             return (
               <>
-                <CodexThinkingSubMenu
-                  thinkings={selectedCodexModel.thinkings}
-                  selectedThinking={codex.selectedThinking}
-                  onSelectThinking={codex.onSelectThinking}
+                <ThinkingSubMenu<CodexThinkingLevel>
+                  levels={selectedCodexModel.thinkings}
+                  selected={codex.selectedThinking}
+                  onSelect={codex.onSelectThinking}
+                  formatLabel={formatCodexThinkingLabel}
                 />
                 <CommandSeparator />
               </>

--- a/src/renderer/features/agents/lib/ipc-chat-transport.ts
+++ b/src/renderer/features/agents/lib/ipc-chat-transport.ts
@@ -8,7 +8,6 @@ import {
   type CustomClaudeConfig,
   customClaudeConfigAtom,
   enableTasksAtom,
-  extendedThinkingEnabledAtom,
   historyEnabledAtom,
   normalizeCustomClaudeConfig,
   selectedOllamaModelAtom,
@@ -24,6 +23,7 @@ import {
   MODEL_ID_MAP,
   pendingAuthRetryMessageAtom,
   pendingUserQuestionsAtom,
+  subChatClaudeThinkingAtomFamily,
   subChatModelIdAtomFamily,
 } from "../atoms"
 import { useAgentSubChatStore } from "../stores/sub-chat-store"
@@ -160,12 +160,12 @@ export class IPCChatTransport implements ChatTransport<UIMessage> {
     const metadata = lastAssistant?.metadata as AgentMessageMetadata | undefined
     const sessionId = metadata?.sessionId
 
-    // Read extended thinking setting dynamically (so toggle applies to existing chats)
-    const thinkingEnabled = appStore.get(extendedThinkingEnabledAtom)
-    // Max thinking tokens for extended thinking mode
-    // SDK adds +1 internally, so 64000 becomes 64001 which exceeds Opus 4.5 limit
-    // Using 32000 to stay safely under the 64000 max output tokens limit
-    const maxThinkingTokens = thinkingEnabled ? 32_000 : undefined
+    // Read thinking effort per-subChat (mirrors the model selection)
+    const claudeThinkingLevel = appStore.get(
+      subChatClaudeThinkingAtomFamily(this.config.subChatId),
+    )
+    const effort =
+      claudeThinkingLevel === "off" ? undefined : claudeThinkingLevel
     const historyEnabled = appStore.get(historyEnabledAtom)
     const enableTasks = appStore.get(enableTasksAtom)
 
@@ -208,7 +208,7 @@ export class IPCChatTransport implements ChatTransport<UIMessage> {
             projectPath: this.config.projectPath, // Original project path for MCP config lookup
             mode: currentMode,
             sessionId,
-            ...(maxThinkingTokens && { maxThinkingTokens }),
+            ...(effort && { effort }),
             ...(modelString && { model: modelString }),
             ...(customConfig && { customConfig }),
             ...(selectedOllamaModel && { selectedOllamaModel }),

--- a/src/renderer/features/agents/lib/models.ts
+++ b/src/renderer/features/agents/lib/models.ts
@@ -1,8 +1,38 @@
+export type ClaudeThinkingLevel =
+  | "off"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+
 export const CLAUDE_MODELS = [
-  { id: "opus", name: "Opus", version: "4.6" },
-  { id: "sonnet", name: "Sonnet", version: "4.6" },
-  { id: "haiku", name: "Haiku", version: "4.5" },
+  {
+    id: "opus",
+    name: "Opus",
+    version: "4.6",
+    thinkings: ["off", "low", "medium", "high", "xhigh", "max"] as ClaudeThinkingLevel[],
+  },
+  {
+    id: "sonnet",
+    name: "Sonnet",
+    version: "4.6",
+    thinkings: ["off", "low", "medium", "high"] as ClaudeThinkingLevel[],
+  },
+  {
+    id: "haiku",
+    name: "Haiku",
+    version: "4.5",
+    thinkings: ["off", "low", "medium", "high"] as ClaudeThinkingLevel[],
+  },
 ]
+
+export function formatClaudeThinkingLabel(thinking: ClaudeThinkingLevel): string {
+  if (thinking === "off") return "Off"
+  if (thinking === "xhigh") return "Extra High"
+  if (thinking === "max") return "Max"
+  return thinking.charAt(0).toUpperCase() + thinking.slice(1)
+}
 
 export type CodexThinkingLevel = "low" | "medium" | "high" | "xhigh"
 

--- a/src/renderer/features/agents/main/chat-input-area.tsx
+++ b/src/renderer/features/agents/main/chat-input-area.tsx
@@ -45,7 +45,6 @@ import {
   codexApiKeyAtom,
   codexOnboardingCompletedAtom,
   customClaudeConfigAtom,
-  extendedThinkingEnabledAtom,
   hiddenModelsAtom,
   normalizeCodexApiKey,
   normalizeCustomClaudeConfig,
@@ -55,9 +54,11 @@ import {
 import { trpc } from "../../../lib/trpc"
 import { cn } from "../../../lib/utils"
 import {
+  lastSelectedClaudeThinkingAtom,
   lastSelectedCodexModelIdAtom,
   lastSelectedCodexThinkingAtom,
   lastSelectedModelIdAtom,
+  subChatClaudeThinkingAtomFamily,
   subChatCodexModelIdAtomFamily,
   subChatCodexThinkingAtomFamily,
   subChatModelIdAtomFamily,
@@ -78,6 +79,7 @@ import {
 import {
   CLAUDE_MODELS,
   CODEX_MODELS,
+  type ClaudeThinkingLevel,
   type CodexThinkingLevel,
 } from "../lib/models"
 import type { DiffTextContext, SelectedTextContext } from "../lib/queue-utils"
@@ -472,6 +474,15 @@ export const ChatInputArea = memo(function ChatInputArea({
   const [selectedSubChatCodexThinking, setSelectedSubChatCodexThinking] = useAtom(
     subChatCodexThinkingAtom,
   )
+  const subChatClaudeThinkingAtom = useMemo(
+    () => subChatClaudeThinkingAtomFamily(subChatId),
+    [subChatId],
+  )
+  const [selectedSubChatClaudeThinking, setSelectedSubChatClaudeThinking] =
+    useAtom(subChatClaudeThinkingAtom)
+  const setLastSelectedClaudeThinking = useSetAtom(
+    lastSelectedClaudeThinkingAtom,
+  )
   const setLastSelectedModelId = useSetAtom(lastSelectedModelIdAtom)
   const setLastSelectedCodexModelId = useSetAtom(lastSelectedCodexModelIdAtom)
   const setLastSelectedCodexThinking = useSetAtom(lastSelectedCodexThinkingAtom)
@@ -595,8 +606,37 @@ export const ChatInputArea = memo(function ChatInputArea({
     }
   }, [selectedOllamaModel, currentOllamaModel, availableModels.isOffline])
 
-  // Extended thinking (reasoning) toggle
-  const [thinkingEnabled, setThinkingEnabled] = useAtom(extendedThinkingEnabledAtom)
+  // Clamp Claude thinking to levels the selected model supports (e.g., Haiku lacks "max").
+  const selectedClaudeThinking = useMemo<ClaudeThinkingLevel>(() => {
+    const supported = selectedModel?.thinkings ?? []
+    if (
+      supported.includes(
+        selectedSubChatClaudeThinking as ClaudeThinkingLevel,
+      )
+    ) {
+      return selectedSubChatClaudeThinking as ClaudeThinkingLevel
+    }
+    if (supported.includes("high")) return "high"
+    return supported[0] ?? "off"
+  }, [selectedModel, selectedSubChatClaudeThinking])
+
+  useEffect(() => {
+    const supported = selectedModel?.thinkings ?? []
+    if (
+      supported.length === 0 ||
+      supported.includes(
+        selectedSubChatClaudeThinking as ClaudeThinkingLevel,
+      )
+    ) {
+      return
+    }
+    setSelectedSubChatClaudeThinking(selectedClaudeThinking)
+  }, [
+    selectedModel,
+    selectedSubChatClaudeThinking,
+    selectedClaudeThinking,
+    setSelectedSubChatClaudeThinking,
+  ])
 
   const selectedModelLabel = useMemo(() => {
     if (provider === "codex") {
@@ -1579,8 +1619,11 @@ export const ChatInputArea = memo(function ChatInputArea({
                         recommendedOllamaModel: availableModels.recommendedModel,
                         onSelectOllamaModel: setSelectedOllamaModel,
                         isConnected: isClaudeConnected,
-                        thinkingEnabled,
-                        onThinkingChange: setThinkingEnabled,
+                        selectedThinking: selectedClaudeThinking,
+                        onSelectThinking: (thinking) => {
+                          setSelectedSubChatClaudeThinking(thinking)
+                          setLastSelectedClaudeThinking(thinking)
+                        },
                       }}
                       codex={{
                         models: codexUiModels,

--- a/src/renderer/features/agents/main/new-chat-form.tsx
+++ b/src/renderer/features/agents/main/new-chat-form.tsx
@@ -31,6 +31,7 @@ import {
   agentsDebugModeAtom,
   justCreatedIdsAtom,
   lastSelectedAgentIdAtom,
+  lastSelectedClaudeThinkingAtom,
   lastSelectedCodexModelIdAtom,
   lastSelectedCodexThinkingAtom,
   lastSelectedBranchesAtom,
@@ -58,7 +59,6 @@ import {
   codexApiKeyAtom,
   codexOnboardingCompletedAtom,
   customClaudeConfigAtom,
-  extendedThinkingEnabledAtom,
   hiddenModelsAtom,
   normalizeCodexApiKey,
   normalizeCustomClaudeConfig,
@@ -121,6 +121,7 @@ import {
 import {
   CLAUDE_MODELS,
   CODEX_MODELS,
+  type ClaudeThinkingLevel,
   type CodexThinkingLevel,
 } from "../lib/models"
 // import type { PlanType } from "@/lib/config/subscription-plans"
@@ -327,8 +328,8 @@ export function NewChatForm({
   const [lastSelectedCodexThinking, setLastSelectedCodexThinking] = useAtom(
     lastSelectedCodexThinkingAtom,
   )
-  const [thinkingEnabled, setThinkingEnabled] = useAtom(
-    extendedThinkingEnabledAtom,
+  const [lastSelectedClaudeThinking, setLastSelectedClaudeThinking] = useAtom(
+    lastSelectedClaudeThinkingAtom,
   )
 
   const [selectedModel, setSelectedModel] = useState(
@@ -395,6 +396,34 @@ export function NewChatForm({
     lastSelectedCodexThinking,
     selectedCodexThinking,
     setLastSelectedCodexThinking,
+  ])
+
+  // Clamp Claude thinking to levels the selected model supports.
+  const selectedClaudeThinking = useMemo<ClaudeThinkingLevel>(() => {
+    const supported = selectedModel?.thinkings ?? []
+    if (
+      supported.includes(lastSelectedClaudeThinking as ClaudeThinkingLevel)
+    ) {
+      return lastSelectedClaudeThinking as ClaudeThinkingLevel
+    }
+    if (supported.includes("high")) return "high"
+    return supported[0] ?? "off"
+  }, [selectedModel, lastSelectedClaudeThinking])
+
+  useEffect(() => {
+    const supported = selectedModel?.thinkings ?? []
+    if (
+      supported.length === 0 ||
+      supported.includes(lastSelectedClaudeThinking as ClaudeThinkingLevel)
+    ) {
+      return
+    }
+    setLastSelectedClaudeThinking(selectedClaudeThinking)
+  }, [
+    selectedModel,
+    lastSelectedClaudeThinking,
+    selectedClaudeThinking,
+    setLastSelectedClaudeThinking,
   ])
 
   const selectedChatModel = useMemo(() => {
@@ -1905,8 +1934,8 @@ export function NewChatForm({
                             recommendedOllamaModel: availableModels.recommendedModel,
                             onSelectOllamaModel: setSelectedOllamaModel,
                             isConnected: isClaudeConnected,
-                            thinkingEnabled,
-                            onThinkingChange: setThinkingEnabled,
+                            selectedThinking: selectedClaudeThinking,
+                            onSelectThinking: setLastSelectedClaudeThinking,
                           }}
                           codex={{
                             models: codexUiModels,

--- a/src/renderer/lib/atoms/index.ts
+++ b/src/renderer/lib/atoms/index.ts
@@ -359,16 +359,6 @@ export const activeConfigAtom = atom((get) => {
   return undefined
 })
 
-// Preferences - Extended Thinking
-// When enabled, Claude will use extended thinking for deeper reasoning (128K tokens)
-// Note: Extended thinking disables response streaming
-export const extendedThinkingEnabledAtom = atomWithStorage<boolean>(
-  "preferences:extended-thinking-enabled",
-  true,
-  undefined,
-  { getOnInit: true },
-)
-
 // Preferences - History (Rollback)
 // When enabled, allow rollback to previous assistant messages
 export const historyEnabledAtom = atomWithStorage<boolean>(


### PR DESCRIPTION
Replaces the binary on/off toggle with a per-subChat Off/Low/Medium/High/XHigh/Max selector (filtered per model) using the SDK's new `effort` option; drops the deprecated `maxThinkingTokens`. A one-time migration seeds the new atom from the old boolean so existing preferences carry over.