### PR TITLE
fix: silently recover from Claude Code SESSION_EXPIRED

### DIFF
--- a/src/main/lib/trpc/routers/claude.ts
+++ b/src/main/lib/trpc/routers/claude.ts
@@ -2004,6 +2004,9 @@ ${prompt}
             const MAX_POLICY_RETRIES = 2
             let policyRetryCount = 0
             let policyRetryNeeded = false
+            // Silent retry once if Claude Code reports the conversation session id is unfindable
+            // (e.g. JSONL was cleaned up, sanitized cwd changed). Drops `resume` and starts fresh.
+            let sessionRetryAttempted = false
             let messageCount = 0
             let pendingFinishChunk: UIMessageChunk | null = null
 
@@ -2508,6 +2511,33 @@ ${prompt}
                     .set({ sessionId: null })
                     .where(eq(subChats.id, input.subChatId))
                     .run()
+
+                  // Silent retry once: drop resume options and re-run the same query as a
+                  // fresh conversation. The renderer never sees an error, so the chat doesn't
+                  // flash empty and auto-rename doesn't trigger.
+                  if (
+                    !sessionRetryAttempted &&
+                    !abortController.signal.aborted
+                  ) {
+                    sessionRetryAttempted = true
+                    console.log(
+                      `[claude] Session expired - silent retry as new conversation (sub=${subId})`,
+                    )
+
+                    const opts = queryOptions.options as Record<string, unknown>
+                    delete opts.resume
+                    delete opts.resumeSessionAt
+                    delete opts.forkSession
+                    opts.continue = true
+
+                    // Reset accumulation state so next iteration starts clean
+                    parts.length = 0
+                    currentText = ""
+                    metadata = {}
+                    stderrLines.length = 0
+
+                    continue
+                  }
 
                   errorContext = "Previous session expired. Please try again."
                   errorCategory = "SESSION_EXPIRED"


### PR DESCRIPTION
## Summary

- Silently retry once when Claude Code's SDK reports `No conversation found with session ID: <uuid>` — drop `resume`/`resumeSessionAt`/`forkSession`, set `continue: true`, and re-run the same query as a fresh conversation.
- Renderer never sees the error chunk on the silent path, so the chat instance isn't reset, `messagesLengthRef` doesn't drop to 0, and auto-rename doesn't rewrite the chat title.
- If the retry also fails, the existing `SESSION_EXPIRED` toast still surfaces.

## Why

Today, when the conversation JSONL is cleaned up or the sanitized cwd changes (common in worktree-heavy workflows), the chat window flashed empty and the next user message rewrote the chat title because the renderer briefly thought the chat was empty. Note: despite the user-facing wording, this is **not** an OAuth issue — it's the Claude Code conversation session UUID stored in `subChats.sessionId`. OAuth credentials are untouched.

## Implementation

Single backend change in `src/main/lib/trpc/routers/claude.ts`:

- Add `sessionRetryAttempted` flag alongside the existing `policyRetry*` counters.
- In the `isSessionNotFound` branch of the streamError catch handler: on first hit, mutate `queryOptions.options` (drop resume/resumeSessionAt/forkSession, add `continue: true`), reset accumulation state (`parts`, `currentText`, `metadata`, `stderrLines`), and `continue` the outer `while (true)` loop. No error chunk emitted, no partial assistant message saved.
- Capped at one attempt — second SESSION_EXPIRED falls through to the original error-emit path.

## Test plan

- [ ] `bun run dev`, open a sub-chat that already has messages and a non-default title.
- [ ] Inject a stale sessionId:
  ```
  sqlite3 ~/Library/Application\ Support/Agents\ Dev/data/agents.db \
    "UPDATE sub_chats SET sessionId = 'deadbeef-0000-0000-0000-000000000000' WHERE id = '<subChatId>';"
  ```
- [ ] Send a message in that sub-chat.
- [ ] Verify: no `[SDK ERROR] Category: SESSION_EXPIRED` in renderer console; one `[claude] Session expired - silent retry as new conversation` line in main process logs; existing messages stay visible (chat does not flash empty); title unchanged; reply streams normally; fresh sessionId persisted afterward.
- [ ] Smoke: a normal message in a healthy sub-chat behaves as before, no extra retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)